### PR TITLE
Use activeWindow/activeDocument and harden release supply chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,14 @@ on:
 
 permissions:
   contents: write
+  id-token: write # required for build provenance / artifact attestations
+  attestations: write # lets the run record signed attestations for the assets
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      VT_API_KEY: ${{ secrets.VT_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,6 +32,30 @@ jobs:
             echo "Tag ${GITHUB_REF_NAME} != manifest version $manifest_version" >&2
             exit 1
           fi
+      # Signed, verifiable provenance for every release asset. Clears the
+      # "Missing GitHub artifact attestations" finding and lets anyone run
+      # `gh attestation verify <file> -R <owner>/<repo>` against the download.
+      - name: Attest release assets
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
+
+      # Free malware scan of the release assets. Uses the VirusTotal free API
+      # (set the VT_API_KEY secret from a free virustotal.com account). Clears
+      # the "Malware scan not available" disclosure with a public scan link.
+      - name: Malware scan (VirusTotal)
+        if: env.VT_API_KEY != ''
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ env.VT_API_KEY }}
+          files: |
+            main.js
+            manifest.json
+            styles.css
+
       - name: Create release with Obsidian assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # Real gate. Requires Dependency graph (Settings > Code security), now enabled.
     steps:
       - uses: actions/checkout@v7
         with:

--- a/src/obsidian/main.ts
+++ b/src/obsidian/main.ts
@@ -336,7 +336,7 @@ function renderMindmap(
 
   plugin.registerDomEvent(activeDocument, "fullscreenchange", () => {
     fsBtn.toggleClass("on", activeDocument.fullscreenElement === wrapEl);
-    window.requestAnimationFrame(fit);
+    activeWindow.requestAnimationFrame(fit);
     // left fullscreen with a deferred persist queued -> flush it now
     if (activeDocument.fullscreenElement !== wrapEl && pendingWrite) {
       const cfgToWrite = pendingWrite;
@@ -1043,14 +1043,14 @@ function renderMindmap(
     drag = { x: e.clientX - view.x, y: e.clientY - view.y };
     stage.classList.add("mm-drag");
   });
-  plugin.registerDomEvent(window, "mousemove", (e: MouseEvent) => {
+  plugin.registerDomEvent(activeWindow, "mousemove", (e: MouseEvent) => {
     if (drag) {
       view.x = e.clientX - drag.x;
       view.y = e.clientY - drag.y;
       apply();
     }
   });
-  plugin.registerDomEvent(window, "mouseup", () => {
+  plugin.registerDomEvent(activeWindow, "mouseup", () => {
     drag = null;
     stage.classList.remove("mm-drag");
   });
@@ -1094,5 +1094,5 @@ function renderMindmap(
     draw();
   }
   // first fit after the element has real dimensions
-  window.requestAnimationFrame(fit);
+  activeWindow.requestAnimationFrame(fit);
 }

--- a/src/obsidian/modals.ts
+++ b/src/obsidian/modals.ts
@@ -55,7 +55,7 @@ class PromptModal extends Modal {
     const row = contentEl.createDiv({ cls: "mm-prompt-actions" });
     row.createEl("button", { text: "Save", cls: "mod-cta" }).onclick = submit;
     row.createEl("button", { text: "Cancel" }).onclick = () => this.close();
-    window.setTimeout(() => {
+    activeWindow.setTimeout(() => {
       input.focus();
       input.select();
     }, 0);


### PR DESCRIPTION
Addresses three findings from the latest plugin review (review stays Satisfactory; these are warnings/disclosures, not blockers).

## Popout-window compatibility (Warning: use `activeDocument`)
Replaced the remaining bare global `window` references in the Obsidian bundle with `activeWindow`:
- `src/obsidian/main.ts` — `requestAnimationFrame` ×2, `registerDomEvent(window, ...)` for `mousemove`/`mouseup`
- `src/obsidian/modals.ts` — `setTimeout`

Bundled `main.js` now has **zero** bare global `window`/`document`.

## Supply chain (release workflow)
- **Artifact attestations** via `actions/attest-build-provenance@v1` (+ `id-token`/`attestations` perms) → clears *Missing GitHub artifact attestations*. Verify with `gh attestation verify <file> -R kikocastro/markdown-mindmap`.
- **Free malware scan** via `crazy-max/ghaction-virustotal@v4`, gated on a `VT_API_KEY` secret → clears *Malware scan not available*. Auto-skips until the secret is set.

## After merge (not in this PR)
1. Add free `VT_API_KEY` repo secret (virustotal.com free account).
2. `npm version patch && git push --follow-tags` from `main` to cut the release that clears all three findings.

Tests: 170 passing, 100% coverage. Build clean.

🧙 Built with [WOZCODE](https://wozcode.com)