### PR TITLE
Gantt/kanban polish + gantt density toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,15 +208,17 @@ filter: [status, tags]
 
 **`gantt`** — field names are frontmatter properties, like everything else:
 
-| Key         | Type                           | Meaning                                                                                                    |
-| ----------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `start`     | field                          | Start date (ISO, e.g. `2026-06-09`). **Required.**                                                         |
-| `end`       | field                          | End/due date. **Required.**                                                                                |
-| `progress`  | field (0–100)                  | Bar fill. Defaults to the card's `progress` field.                                                         |
-| `scale`     | `week` \| `month` \| `quarter` | Axis tick unit (default `month`).                                                                          |
-| `groupRows` | bool                           | Default `true`: rows follow the tree order with subtasks indented under parents. `false`: flat path order. |
+| Key           | Type                                     | Meaning                                                                                                                                                  |
+| ------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `start`       | field                                    | Start date (ISO, e.g. `2026-06-09`). **Required.**                                                                                                       |
+| `end`         | field                                    | End/due date. **Required.**                                                                                                                              |
+| `progress`    | field (0–100)                            | Bar fill. Defaults to the card's `progress` field.                                                                                                       |
+| `scale`       | `week` \| `month` \| `quarter` \| `year` | Axis tick unit (default `month`). Also switchable from the toolbar's Scale chips.                                                                        |
+| `density`     | `compact` \| `comfortable`               | Default `compact`. `comfortable` scales up rows and fonts for reading from a distance (presentations). Also switchable from the toolbar's Density chips. |
+| `sortByStart` | bool                                     | Default `true`: rows sort by crescent start date (dateless last). `false` restores the raw tree/path order.                                              |
+| `groupRows`   | bool                                     | Default `true`: rows follow the tree order with subtasks indented under parents. `false`: flat path order.                                               |
 
-Rows render as bars from `start` to `end` with a progress fill. A task whose `start` equals its `end` (or that has only one of the two) renders as a **milestone diamond**. Tasks with neither date get a plain row. Click a row to open the note.
+Rows render as bars from `start` to `end` with a progress fill. A task whose `start` equals its `end` (or that has only one of the two) renders as a **milestone diamond**. Tasks with neither date get a plain row. Click a row to open the note. The card's `labels` render as pills right of the bar (or at the axis origin for dateless rows). Nested items can be contracted/expanded with a per-row toggle — the same collapse state as the map view, so saved views' collapsed lists apply here too. The toolbar's **show subtasks** chip (under **Rows**) expands/contracts every parent row at once; it's off by default, so the gantt opens with nested rows hidden.
 
 **`kanban`**
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -93,12 +93,19 @@ export type ViewMode = "map" | "gantt" | "kanban";
 
 // gantt view: field names for the date range + bar fill, all configurable like
 // every card field. Milestone = start == end, or one of the two missing.
+export type GanttScale = "week" | "month" | "quarter" | "year";
+// comfortable = bigger rows/fonts for reading from a distance (presentations)
+export type GanttDensity = "compact" | "comfortable";
 export interface GanttCfg {
   start: string; // frontmatter field with the start date (ISO)
   end: string; // frontmatter field with the end/due date (ISO)
   progress?: string; // 0-100 field for the bar fill (defaults to card progress)
-  scale?: "week" | "month" | "quarter"; // axis tick unit (default month)
+  status?: string; // frontmatter field driving the status colour (default "status")
+  scale?: GanttScale; // axis tick unit (default month)
+  density?: GanttDensity; // default compact; comfortable = larger for presentations
   groupRows?: boolean; // default true: DFS tree order + indent; false: flat path order
+  sortByStart?: boolean; // default true: rows sorted by crescent start date (dateless last)
+  showLabels?: boolean; // default true: render card.labels pills in the left label column
 }
 
 // kanban view: group visible nodes into columns by a frontmatter field
@@ -121,6 +128,10 @@ export interface MapCfg {
   levels: LevelCfg[];
   edges?: EdgeCfg[];
   filter?: string[];
+  // when true, filters keep hierarchy context: a matching node's subtasks and
+  // ancestors stay visible even if they don't match themselves (default false:
+  // strict — a filtered-out node hides itself + its primary subtree)
+  filterKeepsHierarchy?: boolean;
   filterLabels?: Record<string, string>; // property -> display name for its filter group
   layout?: LayoutCfg;
   gantt?: GanttCfg;

--- a/src/core/export.ts
+++ b/src/core/export.ts
@@ -2,6 +2,8 @@
 // buttons in the Obsidian adapter. No DOM here — the adapter clones the live
 // SVG for HTML and feeds geometry from the RenderModel for Excalidraw.
 
+import type { RenderModel } from "./render-model";
+
 // ---- export --------------------------------------------------------------
 
 // HTML export destination: sibling of the note, ".md" swapped for " mindmap.html".
@@ -156,6 +158,80 @@ export const mapToExcalidraw = (
     appState: { gridSize: null, viewBackgroundColor: "#ffffff" },
     files: {},
   };
+};
+
+// A card's label: the title, plus the sub line unless titles are collapsed.
+const cardText = (title: string, sub: string, titleOnly: boolean): string =>
+  !titleOnly && sub ? title + "\n" + sub : title;
+
+// gantt v1 geometry constants
+const MIN_BAR_W = 8; // ponytail: sub-day / zero-width bars still need a visible box
+const MILESTONE = 14; // ponytail: no diamond primitive — a small square at the milestone x
+
+// Pure RenderModel -> Excalidraw geometry, dispatching on the view actually in
+// the model so the export mirrors what's on screen. Feed the result to
+// mapToExcalidraw (nodes + edges -> the v2 file).
+// ponytail: gantt drops the axis / ticks / today-line and the hierarchy arrows
+// (row order + indent carry it), kanban drops the swimlane framing; both emit
+// rectangles only. Same lossy v1 ceiling as mapToExcalidraw.
+export const modelToExcalidraw = (
+  model: RenderModel
+): { nodes: ExNode[]; edges: ExEdge[] } => {
+  if (model.view === "gantt") {
+    const g = model.gantt!; // render-model guarantees gantt is set for this view
+    const nodes: ExNode[] = g.rows.map((r) => {
+      if (r.bar)
+        return {
+          x: r.bar.x,
+          y: r.y,
+          w: Math.max(r.bar.w, MIN_BAR_W),
+          h: r.h,
+          color: r.color,
+          text: r.label,
+        };
+      if (r.milestone)
+        return {
+          x: r.milestone.x - MILESTONE / 2,
+          y: r.y,
+          w: MILESTONE,
+          h: MILESTONE,
+          color: r.color,
+          text: r.label,
+        };
+      // dateless row: park a rect in the left label column so nothing is dropped
+      return {
+        x: 0,
+        y: r.y,
+        w: g.labelWidth,
+        h: r.h,
+        color: r.color,
+        text: r.label,
+      };
+    });
+    return { nodes, edges: [] };
+  }
+
+  // map + kanban are both card-based; model.edges is [] for kanban, so the
+  // edge mapping is a no-op there and only the map emits arrows.
+  const nodes: ExNode[] = model.nodes.map((n) => ({
+    x: n.x,
+    y: n.y,
+    w: n.w,
+    h: n.h,
+    color: n.color,
+    text: cardText(n.title, n.sub, model.titleOnly),
+  }));
+  const index = new Map(model.nodes.map((n, i) => [n.id, i]));
+  const edges: ExEdge[] = model.edges.map((e) => ({
+    x1: e.x1,
+    y1: e.y1,
+    x2: e.x2,
+    y2: e.y2,
+    color: e.color,
+    source: index.get(e.a),
+    target: index.get(e.b),
+  }));
+  return { nodes, edges };
 };
 
 // Excalidraw export destination: sibling of the note, ".md" -> ".excalidraw".

--- a/src/core/layout-gantt.ts
+++ b/src/core/layout-gantt.ts
@@ -5,19 +5,52 @@
 // everywhere) and no date-range filtering (filterOptions is discrete-string
 // based) — both deliberate v1 ceilings.
 
-import { MNode, MapCfg } from "./config";
-import { getPath, num, scalarStr } from "./helpers";
-import { treeSequence } from "./layout-tree";
+import { GanttDensity, GanttScale, MNode, MapCfg } from "./config";
+import { CARD_METRICS, getPath, num, primKids, scalarStr } from "./helpers";
+
+// density multipliers applied to the compact base geometry below
+const DENSITY: Record<GanttDensity, number> = { compact: 1, comfortable: 1.4 };
+
+// status string -> bar/milestone colour. Normalized case/space-insensitively;
+// unknown or missing statuses return null (caller falls back to the node colour).
+const STATUS_COLOR: Record<string, string> = {
+  done: "#2ecc71",
+  complete: "#2ecc71",
+  completed: "#2ecc71",
+  closed: "#2ecc71",
+  shipped: "#2ecc71",
+  "in progress": "#3498db",
+  "in-progress": "#3498db",
+  doing: "#3498db",
+  active: "#3498db",
+  wip: "#3498db",
+  started: "#3498db",
+  ongoing: "#3498db",
+  todo: "#95a5a6",
+  "to do": "#95a5a6",
+  "to-do": "#95a5a6",
+  planned: "#95a5a6",
+  backlog: "#95a5a6",
+  open: "#95a5a6",
+  "not started": "#95a5a6",
+  new: "#95a5a6",
+  pending: "#95a5a6",
+};
+export const statusColor = (v: unknown): string | null => {
+  const s = scalarStr(v).trim().toLowerCase().replace(/\s+/g, " ");
+  return s ? (STATUS_COLOR[s] ?? null) : null;
+};
 
 // gantt drawing constants (labelWidth also anchors the time axis origin)
 export const GANTT = {
   labelWidth: 260,
-  rowH: 30,
+  // tall enough for a 2-line title + a tags line in the label column
+  rowH: 50,
   rowGap: 6,
   top: 64,
   axisY: 36,
   indent: 14, // px per hierarchy depth on the row label
-  dayPx: { week: 12, month: 4, quarter: 1.5 },
+  dayPx: { week: 12, month: 4, quarter: 1.5, year: 0.4 },
 } as const;
 
 const DAY_MS = 86400000;
@@ -54,37 +87,71 @@ export interface GanttRow {
   color: string;
   bar: { x: number; w: number; progressW: number | null } | null;
   milestone: { x: number } | null; // diamond centre
+  labelText: string; // card.labels joined, drawn as discreet text right after the row title
+  tooltip: string; // native hover title on the bar/milestone (name + dates + status)
+  hasKids: boolean; // has primary children (drives the collapse toggle)
+  collapsed: boolean;
 }
 export interface GanttTick {
   x: number;
   label: string;
+  major: boolean; // start of the next-larger period (week->month, month/quarter->year boundary etc.)
+}
+// row geometry + font sizes, scaled by density; the renderer reads these
+// instead of hardcoding, so compact/comfortable is one number in one place.
+export interface GanttMetrics {
+  rowH: number;
+  titleSize: number;
+  subSize: number;
+  barH: number;
+  lineH: number; // baseline step between wrapped title lines
+  indent: number; // px per hierarchy depth on the row label
 }
 export interface GanttModel {
   labelWidth: number;
   axisY: number;
+  metrics: GanttMetrics;
   rows: GanttRow[];
   ticks: GanttTick[];
+  todayX: number | null; // x of the "today" marker, or null if out of range / no ticks
   contentRight: number;
   contentBottom: number;
 }
 
-// period starts covering [minDay, maxDay], padded to scale boundaries
+// period starts covering [minDay, maxDay], padded to scale boundaries. `major`
+// flags the boundary of the next-larger period (week->new month, month->new
+// quarter, quarter->new year, year->new decade) so the renderer can draw a
+// slightly firmer divider there.
+type TickDay = { day: number; label: string; major: boolean };
 function tickDays(
   minDay: number,
   maxDay: number,
-  scale: "week" | "month" | "quarter"
-): { day: number; label: string }[] {
-  const out: { day: number; label: string }[] = [];
+  scale: GanttScale
+): TickDay[] {
+  const out: TickDay[] = [];
   if (scale === "week") {
     // floor to Monday (day 0, 1970-01-01, was a Thursday: Monday-based dow = day + 3)
     let d = minDay - ((minDay + 3) % 7);
+    let prevMonth = -1;
     for (; ; d += 7) {
       const dt = new Date(d * DAY_MS);
+      const m = dt.getUTCMonth();
       out.push({
         day: d,
-        label: `${dt.getUTCDate()} ${MONTHS[dt.getUTCMonth()]}`,
+        label: `${dt.getUTCDate()} ${MONTHS[m]}`,
+        major: m !== prevMonth, // first week landing in a new month
       });
+      prevMonth = m;
       if (d > maxDay) break;
+    }
+    return out;
+  }
+  if (scale === "year") {
+    let y = new Date(minDay * DAY_MS).getUTCFullYear();
+    for (; ; y++) {
+      const day = Math.floor(Date.UTC(y, 0, 1) / DAY_MS);
+      out.push({ day, label: `${y}`, major: y % 10 === 0 }); // decade boundary
+      if (day > maxDay) break;
     }
     return out;
   }
@@ -97,6 +164,9 @@ function tickDays(
     out.push({
       day,
       label: scale === "quarter" ? `Q${m / 3 + 1} ${y}` : `${MONTHS[m]} ${y}`,
+      // quarter view: firmer line at the year start (Q1); month view: at the
+      // quarter start (Jan/Apr/Jul/Oct).
+      major: scale === "quarter" ? m === 0 : m % 3 === 0,
     });
     if (day > maxDay) break;
     m += step;
@@ -121,38 +191,113 @@ function depth(nodes: Record<string, MNode>, id: string): number {
   return d;
 }
 
+export interface GanttOpts {
+  collapsed?: Set<string>; // for the per-row toggle state
+  scale?: GanttScale; // UI override of cfg.gantt.scale
+  density?: GanttDensity; // UI override of cfg.gantt.density
+  today?: number; // UTC day number for the "today" marker (adapter supplies live value)
+}
+
 export function layoutGantt(
   cfg: MapCfg,
   nodes: Record<string, MNode>,
   byLevel: MNode[][],
-  vis: Set<string>
+  vis: Set<string>,
+  opts: GanttOpts = {}
 ): GanttModel {
   const g = cfg.gantt;
   if (!g || !g.start || !g.end)
     throw new Error("gantt view needs `gantt: { start, end }` field names.");
-  const scale = g.scale ?? "month";
+  const scale = opts.scale ?? g.scale ?? "month";
   const px = GANTT.dayPx[scale];
+  const den = DENSITY[opts.density ?? g.density ?? "compact"];
+  const metrics: GanttMetrics = {
+    rowH: Math.round(GANTT.rowH * den),
+    titleSize: CARD_METRICS.titleSize * den,
+    subSize: CARD_METRICS.subSize * den,
+    barH: Math.round(14 * den),
+    lineH: Math.round(15 * den),
+    indent: Math.round(GANTT.indent * den),
+  };
+  const rowGap = Math.round(GANTT.rowGap * den);
   const groupRows = g.groupRows !== false;
+  const sortByStart = g.sortByStart !== false;
 
-  const ids = groupRows
-    ? treeSequence(cfg, nodes, byLevel, vis)
-    : [...vis].sort((a, b) => a.localeCompare(b));
+  // start-date key: start, else end, else +Inf so dateless rows sort last.
+  const startKey = (id: string) =>
+    parseDay(getPath(nodes[id].fm, g.start)) ??
+    parseDay(getPath(nodes[id].fm, g.end)) ??
+    Number.POSITIVE_INFINITY;
 
-  // resolve each row's day range first so the axis can span them all
-  const dated = ids.map((id) => {
-    const fm = nodes[id].fm;
-    return {
-      id,
-      start: parseDay(getPath(fm, g.start)),
-      end: parseDay(getPath(fm, g.end)),
+  // default order: crescent start date, but children stay grouped UNDER their
+  // parent — siblings (and roots) are sorted among themselves, the tree is not
+  // flattened. `x || tiebreak`: two dateless give Inf-Inf=NaN (falsy) so they
+  // fall through to the stable collIdx tiebreak.
+  const cmp = sortByStart
+    ? (a: string, b: string) =>
+        startKey(a) - startKey(b) || nodes[a].collIdx - nodes[b].collIdx
+    : (a: string, b: string) => nodes[a].collIdx - nodes[b].collIdx;
+
+  const ids = groupRows ? orderTree() : flatOrder();
+
+  // hierarchical order: sort roots (any node with no visible primary parent) by
+  // `cmp`, DFS, sorting each node's visible children by `cmp` too.
+  function orderTree(): string[] {
+    const seq: string[] = [];
+    const seen = new Set<string>();
+    // ponytail: no revisit guard needed. primKids keys on the single
+    // primaryParent, so the root-reachable set is a forest; true cycles never
+    // reach a root and fall to the trailing unreached loop below.
+    const dfs = (id: string) => {
+      seen.add(id);
+      seq.push(id);
+      primKids(nodes, id)
+        .filter((k) => vis.has(k))
+        .sort(cmp)
+        .forEach(dfs);
     };
-  });
+    const isRoot = (id: string) => {
+      const p = nodes[id].primaryParent;
+      return !p || !nodes[p] || !vis.has(p);
+    };
+    cfg.levels
+      .flatMap((_, li) => byLevel[li])
+      .filter((n) => vis.has(n.id) && isRoot(n.id))
+      .map((n) => n.id)
+      .sort(cmp)
+      .forEach(dfs);
+    // anything still unreached (primary-parent cycle) appended stably
+    cfg.levels.forEach((_, li) =>
+      byLevel[li].forEach((n) => {
+        if (vis.has(n.id) && !seen.has(n.id)) {
+          seen.add(n.id);
+          seq.push(n.id);
+        }
+      })
+    );
+    return seq;
+  }
+  function flatOrder(): string[] {
+    const flat = [...vis].sort((a, b) => a.localeCompare(b));
+    if (!sortByStart) return flat;
+    const pos = new Map(flat.map((id, i) => [id, i]));
+    return [...flat].sort(
+      (a, b) => startKey(a) - startKey(b) || pos.get(a)! - pos.get(b)!
+    );
+  }
+
+  const dated = ids.map((id) => ({
+    id,
+    start: parseDay(getPath(nodes[id].fm, g.start)),
+    end: parseDay(getPath(nodes[id].fm, g.end)),
+  }));
   const allDays = dated.flatMap((d) =>
     [d.start, d.end].filter((x): x is number => x != null)
   );
 
   let ticks: GanttTick[] = [];
   let day0: number | null = null;
+  let todayX: number | null = null;
   let chartRight = GANTT.labelWidth + 40;
   const dayX = (day: number) => GANTT.labelWidth + (day - day0!) * px;
   if (allDays.length) {
@@ -162,17 +307,26 @@ export function layoutGantt(
       scale
     );
     day0 = tickList[0].day;
-    ticks = tickList.map((t) => ({ x: dayX(t.day), label: t.label }));
+    ticks = tickList.map((t) => ({
+      x: dayX(t.day),
+      label: t.label,
+      major: t.major,
+    }));
     chartRight = ticks[ticks.length - 1].x;
+    const lastDay = tickList[tickList.length - 1].day;
+    if (opts.today != null && opts.today >= day0 && opts.today <= lastDay)
+      todayX = dayX(opts.today);
   }
 
+  const showLabels = g.showLabels !== false;
+  const fmtDay = (d: number) => new Date(d * DAY_MS).toISOString().slice(0, 10);
   const rows: GanttRow[] = dated.map(({ id, start, end }, i) => {
     const n = nodes[id];
-    const y = GANTT.top + i * (GANTT.rowH + GANTT.rowGap);
+    const y = GANTT.top + i * (metrics.rowH + rowGap);
     let bar: GanttRow["bar"] = null;
     let milestone: GanttRow["milestone"] = null;
+    const p = g.progress ? num(getPath(n.fm, g.progress)) : n.progress;
     if (start != null && end != null && end > start) {
-      const p = g.progress ? num(getPath(n.fm, g.progress)) : n.progress;
       const w = (end - start) * px;
       bar = {
         x: dayX(start),
@@ -183,26 +337,54 @@ export function layoutGantt(
       // start == end, or only one of the two present: a milestone diamond
       milestone = { x: dayX((start ?? end)!) };
     }
+    const rowIndent = groupRows ? depth(nodes, id) : 0;
+    // tags render as one discreet run right after the row title (renderer places
+    // + truncates them); joined here, not positioned.
+    const labelText = showLabels ? n.labels.join(" · ") : "";
+    // native hover tooltip on the bar/milestone: full title + dates + status
+    const range =
+      start != null && end != null
+        ? `${fmtDay(start)} → ${fmtDay(end)}`
+        : start != null || end != null
+          ? fmtDay((start ?? end)!)
+          : "";
+    const statusText = scalarStr(getPath(n.fm, g.status ?? "status")).trim();
+    // rich hover tooltip: title, then labelled detail lines for whatever exists
+    const tooltip = [
+      n.title,
+      range,
+      statusText && `Status: ${statusText}`,
+      p != null && `Progress: ${Math.round(Math.max(0, Math.min(100, p)))}%`,
+      labelText && `Tags: ${labelText}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
     return {
       id,
       y,
-      h: GANTT.rowH,
+      h: metrics.rowH,
       label: n.title,
-      indent: groupRows ? depth(nodes, id) : 0,
-      color: n.color,
+      indent: rowIndent,
+      color: statusColor(getPath(n.fm, g.status ?? "status")) ?? n.color,
       bar,
       milestone,
+      labelText,
+      tooltip,
+      hasKids: primKids(nodes, id).length > 0,
+      collapsed: opts.collapsed?.has(id) ?? false,
     };
   });
 
   return {
     labelWidth: GANTT.labelWidth,
     axisY: GANTT.axisY,
+    metrics,
     rows,
     ticks,
+    todayX,
     contentRight: chartRight,
     contentBottom: rows.length
-      ? rows[rows.length - 1].y + GANTT.rowH
+      ? rows[rows.length - 1].y + metrics.rowH
       : GANTT.top,
   };
 }

--- a/src/core/render-model.ts
+++ b/src/core/render-model.ts
@@ -9,6 +9,8 @@ import {
   NoteLike,
   Resolver,
   ViewMode,
+  GanttScale,
+  GanttDensity,
   resolveLayout,
   validateConfig,
 } from "./config";
@@ -26,6 +28,9 @@ export interface UiState {
   focused?: string | null;
   titleOnly?: boolean;
   view?: ViewMode; // toolbar override of cfg.view
+  ganttScale?: GanttScale; // toolbar override of cfg.gantt.scale
+  ganttDensity?: GanttDensity; // toolbar override of cfg.gantt.density
+  today?: number; // UTC day number for the gantt "today" marker (adapter supplies live value)
 }
 
 export interface RNode {
@@ -146,7 +151,12 @@ export function modelFromGraph(
   // filters/collapse/focus applied above, BEFORE any layout, so chips, saved
   // views, and search behave identically in all three views.
   if (view === "gantt") {
-    const gantt = layoutGantt(cfg, nodes, byLevel, vis);
+    const gantt = layoutGantt(cfg, nodes, byLevel, vis, {
+      collapsed,
+      scale: ui.ganttScale,
+      density: ui.ganttDensity,
+      today: ui.today,
+    });
     return {
       ...base,
       nodes: [],

--- a/src/core/visibility.ts
+++ b/src/core/visibility.ts
@@ -24,6 +24,8 @@ export function computeVisible(
   filters: Record<string, Set<string>>,
   cfg: MapCfg
 ): Set<string> {
+  if (cfg.filterKeepsHierarchy)
+    return hierarchyVisible(nodes, collapsed, filters, cfg);
   const excluded = new Set<string>();
   Object.values(nodes).forEach((n) => {
     if (!passesFilters(n, filters, cfg)) excluded.add(n.id);
@@ -45,6 +47,66 @@ export function computeVisible(
     if (!hidden.has(n.id)) vis.add(n.id);
   });
   return vis;
+}
+
+// hierarchy-aware filtering: a node is kept when it passes the filters, when a
+// primary ancestor positively matches (subtasks ride along), or when a primary
+// descendant positively matches (ancestors stay as context). "Positive" means
+// the node actually HAS the selected property with a selected value — a node
+// merely lacking the property is unconstrained but never anchors context.
+// Collapse still hides the subtree under a contracted node.
+function hierarchyVisible(
+  nodes: Record<string, MNode>,
+  collapsed: Set<string>,
+  filters: Record<string, Set<string>>,
+  cfg: MapCfg
+): Set<string> {
+  const positivelyMatches = (n: MNode): boolean =>
+    (cfg.filter || []).every((p) => {
+      const sel = filters[p];
+      if (!sel || !sel.size) return true;
+      return fieldArr(n.fm, p).some((v) => sel.has(v));
+    });
+
+  const kept = new Set<string>();
+  const anchors: string[] = [];
+  Object.values(nodes).forEach((n) => {
+    if (passesFilters(n, filters, cfg)) kept.add(n.id);
+    if (positivelyMatches(n)) anchors.push(n.id);
+  });
+  anchors.forEach((id) => {
+    // upward: ancestors as context (cycle-guarded)
+    const seen = new Set<string>();
+    let cur = nodes[id].primaryParent;
+    while (cur && nodes[cur] && !seen.has(cur)) {
+      seen.add(cur);
+      kept.add(cur);
+      cur = nodes[cur].primaryParent;
+    }
+    // downward: the whole primary subtree rides along
+    const stack = [...primKids(nodes, id)];
+    while (stack.length) {
+      const x = stack.pop()!;
+      if (kept.has(x)) continue;
+      kept.add(x);
+      stack.push(...primKids(nodes, x));
+    }
+  });
+
+  // collapse applies last: contracted nodes keep self, hide their subtree
+  const hidden = new Set<string>();
+  collapsed.forEach((rid) => {
+    if (!nodes[rid]) return;
+    const stack = [...primKids(nodes, rid)];
+    while (stack.length) {
+      const x = stack.pop()!;
+      if (!hidden.has(x)) {
+        hidden.add(x);
+        stack.push(...primKids(nodes, x));
+      }
+    }
+  });
+  return new Set([...kept].filter((id) => !hidden.has(id)));
 }
 
 // Focus is a pure tree filter over primary layout links. Null, empty, or stale

--- a/src/obsidian/main.ts
+++ b/src/obsidian/main.ts
@@ -23,6 +23,8 @@ import {
   Resolver,
   SavedViewCfg,
   ViewMode,
+  GanttScale,
+  GanttDensity,
   collectNodes,
   buildEdges,
   isSecondary,
@@ -37,6 +39,7 @@ import {
   mindmapExportPath,
   mindmapExcalidrawPath,
   mapToExcalidraw,
+  modelToExcalidraw,
 } from "../graph";
 import { renderModel } from "../render/renderer";
 import { attachPanZoom } from "../render/panzoom";
@@ -127,6 +130,9 @@ function renderMindmap(
   let savedViews: SavedViewCfg[] = [...(cfg.views || [])];
   let selectedView = "";
   let viewMode: ViewMode = cfg.view ?? "map";
+  // ponytail: not persisted into saved views yet
+  let ganttScale: GanttScale = cfg.gantt?.scale ?? "month";
+  let ganttDensity: GanttDensity = cfg.gantt?.density ?? "compact";
   let searchTerm = "";
   let selected: string | null = null;
   let focused: string | null = null;
@@ -186,6 +192,8 @@ function renderMindmap(
   focusTicket.onclick = () => setFocus(null);
 
   // view-mode switcher (map / gantt / kanban), shown when an alt view is configured
+  // declared early (null) so syncModeButtons can reference it before the button is created
+  let titlesBtnEl: HTMLButtonElement | null = null;
   const modeBtns: Partial<Record<ViewMode, HTMLButtonElement>> = {};
   const availableModes: ViewMode[] = [
     "map",
@@ -204,6 +212,8 @@ function renderMindmap(
         selectedView = "";
         syncModeButtons();
         syncViewControls();
+        // entering the gantt with "show subtasks" off starts contracted
+        if (m === "gantt" && !ganttShowSubs) applySubs();
         draw();
         fit();
       };
@@ -213,8 +223,89 @@ function renderMindmap(
     (Object.keys(modeBtns) as ViewMode[]).forEach((m) =>
       modeBtns[m]!.toggleClass("on", m === viewMode)
     );
+    // "Titles only" has no effect in gantt (no cards); hide it there, show elsewhere
+    titlesBtnEl?.toggleClass("mm-hidden", viewMode === "gantt");
   }
   syncModeButtons();
+
+  // gantt scale switcher (week / month / quarter / year), only for gantt blocks
+  const scaleBtns: Partial<Record<GanttScale, HTMLButtonElement>> = {};
+  if (cfg.gantt) {
+    const grp = toolbar.createDiv({ cls: "mm-fltgroup" });
+    grp.createSpan({ cls: "mm-fltlabel", text: "Scale" });
+    (["week", "month", "quarter", "year"] as GanttScale[]).forEach((s) => {
+      const chip = grp.createEl("button", { cls: "mm-chip", text: s });
+      scaleBtns[s] = chip;
+      chip.onclick = () => {
+        if (ganttScale === s) return;
+        ganttScale = s;
+        syncScaleButtons();
+        draw();
+        fit();
+      };
+    });
+  }
+  function syncScaleButtons() {
+    (Object.keys(scaleBtns) as GanttScale[]).forEach((s) =>
+      scaleBtns[s]!.toggleClass("on", s === ganttScale)
+    );
+  }
+  syncScaleButtons();
+
+  // gantt density switcher: comfortable = bigger rows/fonts for presentations
+  const densityBtns: Partial<Record<GanttDensity, HTMLButtonElement>> = {};
+  if (cfg.gantt) {
+    const grp = toolbar.createDiv({ cls: "mm-fltgroup" });
+    grp.createSpan({ cls: "mm-fltlabel", text: "Density" });
+    (["compact", "comfortable"] as GanttDensity[]).forEach((d) => {
+      const chip = grp.createEl("button", { cls: "mm-chip", text: d });
+      densityBtns[d] = chip;
+      chip.onclick = () => {
+        if (ganttDensity === d) return;
+        ganttDensity = d;
+        syncDensityButtons();
+        draw();
+        fit();
+      };
+    });
+  }
+  function syncDensityButtons() {
+    (Object.keys(densityBtns) as GanttDensity[]).forEach((d) =>
+      densityBtns[d]!.toggleClass("on", d === ganttDensity)
+    );
+  }
+  syncDensityButtons();
+
+  // "show subtasks" chip (own "Rows" section, not part of Scale): on by
+  // default = nested rows shown; off = all parents contracted. Reuses the
+  // collapse machinery, so it composes with saved views. ponytail: turning it
+  // on expands all parents, even ones the user had contracted by hand.
+  let ganttShowSubs = true;
+  let subsChip: HTMLButtonElement | null = null;
+  const applySubs = () => {
+    Object.values(nodes).forEach((n) => {
+      if (n.children.size === 0) return;
+      if (ganttShowSubs) collapsed.delete(n.id);
+      else collapsed.add(n.id);
+    });
+  };
+  if (cfg.gantt) {
+    const grp = toolbar.createDiv({ cls: "mm-fltgroup" });
+    grp.createSpan({ cls: "mm-fltlabel", text: "Rows" });
+    subsChip = grp.createEl("button", {
+      cls: "mm-chip",
+      text: "show subtasks",
+      attr: { title: "Show/hide nested items (contracts every parent row)" },
+    });
+    subsChip.toggleClass("on", ganttShowSubs);
+    subsChip.onclick = () => {
+      ganttShowSubs = !ganttShowSubs;
+      subsChip!.toggleClass("on", ganttShowSubs);
+      applySubs();
+      draw();
+      fit();
+    };
+  }
 
   let viewSelect: HTMLSelectElement | null = null;
   let editViewBtn: HTMLButtonElement | null = null;
@@ -352,6 +443,9 @@ function renderMindmap(
     text: "Titles only",
     attr: { title: "Show only node titles" },
   });
+  titlesBtnEl = titlesBtn;
+  // set initial visibility: hidden when the block opens straight into the gantt view
+  titlesBtn.toggleClass("mm-hidden", viewMode === "gantt");
   titlesBtn.onclick = () => {
     titleOnly = !titleOnly;
     titlesBtn.toggleClass("on", titleOnly);
@@ -706,6 +800,9 @@ function renderMindmap(
       focused,
       titleOnly,
       view: viewMode,
+      ganttScale,
+      ganttDensity,
+      today: Math.floor(Date.now() / 86400000),
     };
   }
 
@@ -734,6 +831,16 @@ function renderMindmap(
       (dnAdj[e.a] = dnAdj[e.a] || new Set()).add(e.b);
       (upAdj[e.b] = upAdj[e.b] || new Set()).add(e.a);
     });
+    // gantt/kanban have no edges; build adjacency from the primary parent tree so
+    // hover-highlight walks ancestors + descendants just like the map view does.
+    if (viewMode !== "map") {
+      Object.values(nodes).forEach((n) => {
+        if (!n.primaryParent) return;
+        const p = n.primaryParent;
+        (dnAdj[p] = dnAdj[p] || new Set()).add(n.id);
+        (upAdj[n.id] = upAdj[n.id] || new Set()).add(p);
+      });
+    }
 
     panZoom.apply();
     reapply();
@@ -820,34 +927,15 @@ function renderMindmap(
     );
   }
 
-  // Export the current map as an editable .excalidraw (v2 JSON) next to the
-  // note. Always exports the tree (map) layout, whatever view is on screen:
-  // modelFromGraph re-lays the current collapse/filter/focus state out as a map
-  // and the pure builder in graph.ts does the element mapping.
+  // Export the CURRENT view as an editable .excalidraw (v2 JSON) next to the
+  // note: currentUi() carries the on-screen view (map / gantt / kanban) plus the
+  // live collapse/filter/focus state, so the export mirrors what's showing.
+  // modelToExcalidraw dispatches on the model's view; mapToExcalidraw wraps the
+  // resulting geometry into the file.
   // ponytail: copies the current collapse/filter/titles state, like Export HTML.
   function exportExcalidraw() {
-    const model = modelFromGraph(cfg, nodes, byLevel, edgeKind, {
-      ...currentUi(),
-      view: "map",
-    });
-    const exIndex = new Map(model.nodes.map((n, i) => [n.id, i]));
-    const exNodes = model.nodes.map((n) => ({
-      x: n.x,
-      y: n.y,
-      w: n.w,
-      h: n.h,
-      color: n.color,
-      text: !titleOnly && n.sub ? n.title + "\n" + n.sub : n.title,
-    }));
-    const exEdges = model.edges.map((e) => ({
-      x1: e.x1,
-      y1: e.y1,
-      x2: e.x2,
-      y2: e.y2,
-      color: e.color,
-      source: exIndex.get(e.a),
-      target: exIndex.get(e.b),
-    }));
+    const model = modelFromGraph(cfg, nodes, byLevel, edgeKind, currentUi());
+    const { nodes: exNodes, edges: exEdges } = modelToExcalidraw(model);
     const json = JSON.stringify(mapToExcalidraw(exNodes, exEdges), null, 2);
     const path = mindmapExcalidrawPath(ctx.sourcePath);
     void app.vault.adapter.write(path, json).then(

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -67,12 +67,13 @@ export function renderModel(
 
   // ---- gantt: axis + one row per node (label, bar/diamond) ----
   function drawGantt(gm: GanttModel) {
+    const m = gm.metrics; // density-scaled row height + font sizes
     const gridBottom = Math.max(gm.contentBottom, GANTT.top);
     gm.ticks.forEach((t) => {
       svgEl(
         "line",
         {
-          class: "mm-grid",
+          class: "mm-grid" + (t.major ? " mm-grid-major" : ""),
           x1: t.x,
           y1: gm.axisY + 6,
           x2: t.x,
@@ -88,43 +89,73 @@ export function renderModel(
     });
     gm.rows.forEach((r) => {
       const g = svgEl("g", { class: "mm-node" }, rootG);
-      const indent = 8 + r.indent * GANTT.indent;
-      const label =
-        wrap(
-          r.label,
-          gm.labelWidth - indent - 12,
-          CARD_METRICS.titleSize,
-          1
-        )[0] ?? "";
+      // 20px gutter before every label keeps them aligned whether or not a
+      // collapse toggle is drawn in it
+      const indent = 8 + r.indent * m.indent + 20;
+      // left column: title wrapped to 2 lines (ellipsised if it overflows), with
+      // the tags on their own line below it so they're always fully readable.
+      const colW = gm.labelWidth - indent - 12;
+      const full = r.label.replace(/\s+/g, " ").trim();
+      const titleLines = wrap(full, colW, m.titleSize, 2);
+      // wrap() drops overflow words silently; flag the last line if any were cut
+      if (titleLines.join(" ").length < full.length) {
+        const perChar = m.titleSize * 0.6;
+        const max = Math.max(1, Math.floor(colW / perChar) - 1);
+        const last = titleLines[titleLines.length - 1];
+        titleLines[titleLines.length - 1] =
+          (last.length > max ? last.slice(0, max) : last) + "…";
+      }
+      // vertically center the title (+ optional tags line) block in the row, so
+      // taller comfortable-density rows don't leave the text hugging the top
+      const lineCount = titleLines.length + (r.labelText ? 1 : 0);
+      const firstBaseline = r.y + (r.h - lineCount * m.lineH) / 2 + m.titleSize;
       const txt = svgEl(
         "text",
         {
           class: "mm-t1",
           x: indent,
-          y: r.y + r.h / 2 + 4,
-          "font-size": CARD_METRICS.titleSize,
+          y: firstBaseline,
+          "font-size": m.titleSize,
         },
         g
       );
-      txt.textContent = label;
-      if (label.length < r.label.replace(/\s+/g, " ").trim().length)
-        svgEl("title", {}, g).textContent = r.label;
+      titleLines.forEach((ln, i) => {
+        svgEl(
+          "tspan",
+          i === 0 ? { x: indent } : { x: indent, dy: m.lineH },
+          txt
+        ).textContent = ln;
+      });
+      if (r.labelText)
+        svgEl(
+          "text",
+          {
+            class: "mm-gantt-sub",
+            x: indent,
+            y: firstBaseline + titleLines.length * m.lineH,
+            "font-size": m.subSize,
+          },
+          g
+        ).textContent = r.labelText;
+      // rich tooltip on the whole row (title + dates + status + progress + tags)
+      svgEl("title", {}, g).textContent = r.tooltip;
       const cy = r.y + r.h / 2;
       if (r.bar) {
-        const barY = r.y + (r.h - 14) / 2;
-        svgEl(
+        const barY = r.y + (r.h - m.barH) / 2;
+        const barRect = svgEl(
           "rect",
           {
             x: r.bar.x,
             y: barY,
             width: Math.max(3, r.bar.w),
-            height: 14,
+            height: m.barH,
             rx: 4,
             fill: r.color,
             "fill-opacity": 0.3,
           },
           g
         );
+        svgEl("title", {}, barRect).textContent = r.tooltip;
         if (r.bar.progressW != null)
           svgEl(
             "rect",
@@ -132,26 +163,96 @@ export function renderModel(
               x: r.bar.x,
               y: barY,
               width: r.bar.progressW,
-              height: 14,
+              height: m.barH,
               rx: 4,
               fill: r.color,
             },
             g
           );
+        // card title overlaid on the bar, white, ellipsised to the bar width.
+        // ponytail: char-count width estimate (no SVG text metrics), matches core.
+        const inset = 6;
+        const perChar = m.titleSize * 0.6;
+        const maxChars = Math.floor(
+          (Math.max(3, r.bar.w) - inset * 2) / perChar
+        );
+        let barTitle = r.label.replace(/\s+/g, " ").trim();
+        if (maxChars <= 0) barTitle = "";
+        else if (barTitle.length > maxChars)
+          barTitle = barTitle.slice(0, Math.max(1, maxChars - 1)) + "…";
+        if (barTitle)
+          svgEl(
+            "text",
+            {
+              class: "mm-gantt-bartitle",
+              x: r.bar.x + inset,
+              // baseline ~0.35em below the bar centre keeps the text visually
+              // centred at any font size (the fixed +3 rode high on comfortable)
+              y: cy + m.titleSize * 0.35,
+              "font-size": m.titleSize - 1,
+            },
+            g
+          ).textContent = barTitle;
       } else if (r.milestone) {
         const x = r.milestone.x;
-        svgEl(
+        const d = m.barH / 2; // diamond half-diagonal tracks the bar height
+        const diamond = svgEl(
           "path",
           {
             class: "mm-milestone",
-            d: `M${x},${cy - 7} L${x + 7},${cy} L${x},${cy + 7} L${x - 7},${cy} Z`,
+            d: `M${x},${cy - d} L${x + d},${cy} L${x},${cy + d} L${x - d},${cy} Z`,
             fill: r.color,
           },
           g
         );
+        svgEl("title", {}, diamond).textContent = r.tooltip;
+      }
+      // collapse toggle in the 20px label gutter (same glyphs as the map
+      // toggle); only when the adapter handles toggling (the webview doesn't).
+      // mm-gantt-toggle keeps the muted look — the accent fill is too loud in
+      // a dense chart.
+      if (r.hasKids && cb.onToggle) {
+        const cx = indent - 12;
+        // collapsed toggles get a distinct class + bigger circle so contracted subtrees stand out
+        const tg = svgEl(
+          "g",
+          {
+            class:
+              "mm-toggle mm-gantt-toggle" +
+              (r.collapsed ? " mm-collapsed" : ""),
+          },
+          g
+        );
+        svgEl("circle", { cx, cy, r: r.collapsed ? 8 : 7 }, tg);
+        svgEl("text", { x: cx, y: cy + 4 }, tg).textContent = r.collapsed
+          ? "+"
+          : "−";
+        tg.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          cb.onToggle!(r.id);
+        });
       }
       interact(g, r.id);
     });
+    // vertical "today" marker, drawn last so it sits over the bars
+    if (gm.todayX != null) {
+      svgEl(
+        "line",
+        {
+          class: "mm-today",
+          x1: gm.todayX,
+          y1: gm.axisY + 6,
+          x2: gm.todayX,
+          y2: gridBottom,
+        },
+        rootG
+      );
+      svgEl(
+        "text",
+        { class: "mm-today-label", x: gm.todayX + 3, y: gm.axisY - 8 },
+        rootG
+      ).textContent = "today";
+    }
   }
 
   if (model.view === "gantt" && model.gantt) {

--- a/styles.css
+++ b/styles.css
@@ -245,6 +245,10 @@
 .mm-toolbar .mm-focus-ticket.mm-hidden {
   display: none;
 }
+/* generic hide toggle (e.g. the "Titles only" button in gantt view) */
+.mm-hidden {
+  display: none;
+}
 .mm-focus-label {
   flex: 1 1 auto;
   min-width: 0;
@@ -366,6 +370,18 @@
   stroke: var(--background-modifier-border);
   stroke-width: 1;
 }
+/* firmer divider at the next-larger period boundary (year in quarter view,
+   quarter in month view, month in week view). Firmer, not loud. */
+.mm-grid-major {
+  stroke: var(--text-muted);
+  stroke-width: 1.5;
+  stroke-opacity: 0.55;
+}
+/* tags trailing the gantt row title: quieter + smaller than the title */
+.mm-gantt-sub {
+  fill: var(--text-faint);
+  font-size: 0.82em;
+}
 .mm-axis {
   fill: var(--text-muted);
   font-size: 11px;
@@ -400,6 +416,38 @@
 }
 .mm-toggle.mm-collapsed text {
   fill: var(--text-on-accent);
+}
+/* gantt row toggles stay muted even when contracted — the accent fill reads
+   too strong next to dense chart rows */
+.mm-toggle.mm-gantt-toggle.mm-collapsed circle {
+  fill: var(--background-secondary);
+  stroke: var(--text-muted);
+}
+.mm-toggle.mm-gantt-toggle.mm-collapsed text {
+  fill: var(--text-muted);
+}
+.mm-toggle.mm-gantt-toggle:hover circle {
+  fill: var(--mm-hover);
+  stroke: var(--text-normal);
+}
+
+/* card title overlaid on the gantt bar: white, never intercepts clicks */
+.mm-gantt-bartitle {
+  fill: #fff;
+  font-weight: 600;
+  pointer-events: none;
+}
+/* vertical "today" marker, like a roadmap's now-line */
+.mm-today {
+  stroke: var(--color-red, #e74c3c);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+  pointer-events: none;
+}
+.mm-today-label {
+  fill: var(--color-red, #e74c3c);
+  font-size: 9px;
+  pointer-events: none;
 }
 
 /* ---- causal map (```causalmap) ---- */

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -3,7 +3,16 @@ import {
   mindmapExportPath,
   mindmapExcalidrawPath,
   mapToExcalidraw,
+  modelToExcalidraw,
+  buildRenderModel,
 } from "../src/graph";
+import {
+  simpleCfg,
+  simpleNotes,
+  taskCfg,
+  taskNotes,
+  resolverFor,
+} from "./fixtures";
 
 describe("mindmapExportPath", () => {
   it("puts the .html next to the note, dropping the .md", () => {
@@ -105,6 +114,131 @@ describe("mapToExcalidraw", () => {
     expect(rects[1].boundElements).toContainEqual({
       type: "arrow",
       id: arrow.id,
+    });
+  });
+});
+
+describe("modelToExcalidraw", () => {
+  describe("map view", () => {
+    const model = buildRenderModel(
+      simpleCfg,
+      simpleNotes,
+      resolverFor(simpleNotes),
+      { view: "map" }
+    );
+
+    it("emits one node per map node and one edge per map edge", () => {
+      const { nodes, edges } = modelToExcalidraw(model);
+      expect(nodes).toHaveLength(model.nodes.length);
+      expect(edges).toHaveLength(model.edges.length);
+      expect(edges.length).toBeGreaterThan(0);
+    });
+
+    it("carries node geometry and colour through unchanged", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const first = model.nodes[0];
+      expect(nodes[0]).toMatchObject({
+        x: first.x,
+        y: first.y,
+        w: first.w,
+        h: first.h,
+        color: first.color,
+      });
+    });
+
+    it("appends the sub line to the title when present", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const goal = nodes.find((n) => n.text.startsWith("Goal A"))!;
+      expect(goal.text).toBe("Goal A\nnorth star");
+      // a node without a sub stays a single line
+      const proj = nodes.find((n) => n.text === "Proj 1");
+      expect(proj).toBeTruthy();
+    });
+
+    it("drops the sub line when titles are collapsed", () => {
+      const collapsedTitles = buildRenderModel(
+        simpleCfg,
+        simpleNotes,
+        resolverFor(simpleNotes),
+        { view: "map", titleOnly: true }
+      );
+      const { nodes } = modelToExcalidraw(collapsedTitles);
+      expect(nodes.find((n) => n.text === "Goal A")).toBeTruthy();
+      expect(nodes.some((n) => n.text.includes("\n"))).toBe(false);
+    });
+
+    it("binds each edge to its source/target node indices", () => {
+      const { nodes, edges } = modelToExcalidraw(model);
+      const e = edges[0];
+      expect(e.source).toBeTypeOf("number");
+      expect(e.target).toBeTypeOf("number");
+      expect(nodes[e.source!]).toBeTruthy();
+      expect(nodes[e.target!]).toBeTruthy();
+    });
+  });
+
+  describe("gantt view", () => {
+    const model = buildRenderModel(taskCfg, taskNotes, resolverFor(taskNotes), {
+      view: "gantt",
+    });
+
+    it("emits one node per gantt row and no edges", () => {
+      const { nodes, edges } = modelToExcalidraw(model);
+      expect(nodes).toHaveLength(model.gantt!.rows.length);
+      expect(edges).toEqual([]);
+    });
+
+    it("positions a bar row at its bar geometry", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const row = model.gantt!.rows.find((r) => r.bar)!;
+      const node = nodes.find((n) => n.text === row.label)!;
+      expect(node.x).toBe(row.bar!.x);
+      expect(node.y).toBe(row.y);
+      expect(node.w).toBe(Math.max(row.bar!.w, 8));
+      expect(node.color).toBe(row.color);
+    });
+
+    it("emits a small centred square for a milestone row", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const kickoff = nodes.find((n) => n.text === "Kickoff")!;
+      const row = model.gantt!.rows.find((r) => r.label === "Kickoff")!;
+      expect(row.milestone).toBeTruthy();
+      expect(kickoff.w).toBe(14);
+      expect(kickoff.h).toBe(14);
+      expect(kickoff.x).toBe(row.milestone!.x - 7);
+    });
+
+    it("parks a dateless row in the left label column", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const someday = nodes.find((n) => n.text === "Someday")!;
+      expect(someday.x).toBe(0);
+      expect(someday.w).toBe(model.gantt!.labelWidth);
+    });
+  });
+
+  describe("kanban view", () => {
+    const model = buildRenderModel(taskCfg, taskNotes, resolverFor(taskNotes), {
+      view: "kanban",
+    });
+
+    it("emits one node per card and no edges", () => {
+      const { nodes, edges } = modelToExcalidraw(model);
+      expect(nodes).toHaveLength(model.nodes.length);
+      expect(nodes.length).toBeGreaterThan(0);
+      expect(edges).toEqual([]);
+    });
+
+    it("carries each card's geometry, colour and title", () => {
+      const { nodes } = modelToExcalidraw(model);
+      const card = model.nodes[0];
+      expect(nodes[0]).toMatchObject({
+        x: card.x,
+        y: card.y,
+        w: card.w,
+        h: card.h,
+        color: card.color,
+      });
+      expect(nodes[0].text).toContain(card.title);
     });
   });
 });

--- a/test/gantt.test.ts
+++ b/test/gantt.test.ts
@@ -7,6 +7,7 @@ import {
   computeVisible,
   layoutGantt,
   parseDay,
+  statusColor,
 } from "../src/graph";
 import type { GanttModel, MapCfg } from "../src/graph";
 import { mk, resolverFor, taskCfg, taskNotes } from "./fixtures";
@@ -39,6 +40,27 @@ describe("parseDay", () => {
 
   it("accepts Date values (YAML parsers may emit them)", () => {
     expect(parseDay(new Date(86400000))).toBe(1);
+  });
+});
+
+describe("layoutGantt — density", () => {
+  it("defaults to compact metrics", () => {
+    const g = gantt();
+    expect(g.metrics.rowH).toBe(GANTT.rowH);
+    expect(g.rows[0]?.h).toBe(GANTT.rowH);
+  });
+
+  it("comfortable scales up rows, fonts and taller rows push content down", () => {
+    const { nodes, byLevel, vis } = build();
+    const comfy = layoutGantt(taskCfg, nodes, byLevel, vis, {
+      density: "comfortable",
+    });
+    const compact = layoutGantt(taskCfg, nodes, byLevel, vis, {});
+    expect(comfy.metrics.rowH).toBeGreaterThan(compact.metrics.rowH);
+    expect(comfy.metrics.titleSize).toBeGreaterThan(compact.metrics.titleSize);
+    expect(comfy.metrics.barH).toBeGreaterThan(compact.metrics.barH);
+    expect(comfy.rows[0].h).toBe(comfy.metrics.rowH);
+    expect(comfy.contentBottom).toBeGreaterThan(compact.contentBottom);
   });
 });
 
@@ -95,10 +117,10 @@ describe("layoutGantt — rows", () => {
     g.rows.forEach((r) => expect(r.indent).toBeLessThanOrEqual(2));
   });
 
-  it("keeps folder order and no indent when groupRows is false", () => {
+  it("keeps folder order and no indent when groupRows is false and sorting is off", () => {
     const cfg: MapCfg = {
       ...taskCfg,
-      gantt: { ...taskCfg.gantt!, groupRows: false },
+      gantt: { ...taskCfg.gantt!, groupRows: false, sortByStart: false },
     };
     const g = gantt(cfg);
     // folder (path) order: broker-operator, broker-phase-1, client-dns, kickoff, someday
@@ -110,6 +132,411 @@ describe("layoutGantt — rows", () => {
       "tasks/someday.md",
     ]);
     g.rows.forEach((r) => expect(r.indent).toBe(0));
+  });
+
+  it("flat, start-sorted, no indent when groupRows is off but sorting stays on", () => {
+    const cfg: MapCfg = {
+      ...taskCfg,
+      gantt: { ...taskCfg.gantt!, groupRows: false },
+    };
+    const g = gantt(cfg);
+    // no hierarchy grouping: pure global start-date order, dateless last
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/client-dns.md",
+      "tasks/broker-operator.md",
+      "tasks/broker-phase-1.md",
+      "tasks/kickoff.md",
+      "tasks/someday.md",
+    ]);
+    g.rows.forEach((r) => expect(r.indent).toBe(0));
+  });
+});
+
+describe("layoutGantt — start-date ordering (default)", () => {
+  it("sorts rows by crescent start date, dateless rows last", () => {
+    const g = gantt();
+    // client-dns 2025-12-01, broker-operator + phase-1 2026-06-09 (stable:
+    // parent first), kickoff 2026-06-15, someday dateless
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/client-dns.md",
+      "tasks/broker-operator.md",
+      "tasks/broker-phase-1.md",
+      "tasks/kickoff.md",
+      "tasks/someday.md",
+    ]);
+  });
+
+  it("uses the end date when only the end is present", () => {
+    const notes = [
+      mk("tasks/late.md", {
+        id: "t1",
+        title: "Late",
+        parentId: "",
+        status: "todo",
+        start: "2026-03-09",
+        due: "2026-03-20",
+      }),
+      mk("tasks/only-due.md", {
+        id: "t2",
+        title: "Only due",
+        parentId: "",
+        status: "todo",
+        due: "2026-03-02",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/only-due.md",
+      "tasks/late.md",
+    ]);
+  });
+
+  it("keeps tree order between two dateless rows", () => {
+    const notes = [
+      mk("tasks/undated-a.md", {
+        id: "t2",
+        title: "Undated A",
+        parentId: "",
+        status: "todo",
+      }),
+      mk("tasks/undated-b.md", {
+        id: "t3",
+        title: "Undated B",
+        parentId: "",
+        status: "todo",
+      }),
+      mk("tasks/dated.md", {
+        id: "t1",
+        title: "Dated",
+        parentId: "",
+        status: "todo",
+        start: "2026-03-09",
+        due: "2026-03-20",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/dated.md",
+      "tasks/undated-a.md",
+      "tasks/undated-b.md",
+    ]);
+  });
+
+  it("sortByStart: false restores the DFS tree order", () => {
+    const cfg: MapCfg = {
+      ...taskCfg,
+      gantt: { ...taskCfg.gantt!, sortByStart: false },
+    };
+    const g = gantt(cfg);
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/broker-operator.md",
+      "tasks/broker-phase-1.md",
+      "tasks/client-dns.md",
+      "tasks/kickoff.md",
+      "tasks/someday.md",
+    ]);
+  });
+
+  it("keeps a child grouped under its parent even when the child starts earlier", () => {
+    const notes = [
+      mk("tasks/parent.md", {
+        id: "p",
+        title: "Parent",
+        parentId: "",
+        status: "todo",
+        start: "2026-06-01",
+        due: "2026-06-30",
+      }),
+      mk("tasks/early-child.md", {
+        id: "c",
+        title: "Early child",
+        parentId: "p",
+        status: "todo",
+        start: "2026-01-05",
+        due: "2026-01-20",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    // the child's earlier start does NOT float it above the parent: siblings
+    // and roots are sorted, but children stay nested under their parent.
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/parent.md",
+      "tasks/early-child.md",
+    ]);
+    expect(g.rows[0].indent).toBe(0);
+    expect(g.rows[1].indent).toBe(1);
+  });
+
+  it("sorts sibling children by start date under their shared parent", () => {
+    const notes = [
+      mk("tasks/parent.md", {
+        id: "p",
+        title: "Parent",
+        parentId: "",
+        status: "todo",
+        start: "2026-01-01",
+        due: "2026-12-31",
+      }),
+      mk("tasks/child-late.md", {
+        id: "cl",
+        title: "Child late",
+        parentId: "p",
+        status: "todo",
+        start: "2026-08-01",
+        due: "2026-08-10",
+      }),
+      mk("tasks/child-early.md", {
+        id: "ce",
+        title: "Child early",
+        parentId: "p",
+        status: "todo",
+        start: "2026-02-01",
+        due: "2026-02-10",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    expect(g.rows.map((r) => r.id)).toEqual([
+      "tasks/parent.md",
+      "tasks/child-early.md",
+      "tasks/child-late.md",
+    ]);
+  });
+});
+
+describe("layoutGantt — collapse state on rows", () => {
+  it("flags rows with visible primary children as collapsible", () => {
+    const g = gantt();
+    const parent = g.rows.find((r) => r.id === "tasks/broker-operator.md")!;
+    const leaf = g.rows.find((r) => r.id === "tasks/client-dns.md")!;
+    expect(parent.hasKids).toBe(true);
+    expect(parent.collapsed).toBe(false);
+    expect(leaf.hasKids).toBe(false);
+  });
+
+  it("marks a collapsed row and hides its subtree when ui collapses it", () => {
+    const m = buildRenderModel(taskCfg, taskNotes, resolverFor(taskNotes), {
+      view: "gantt",
+      collapsed: ["tasks/broker-operator.md"],
+    });
+    const ids = m.gantt!.rows.map((r) => r.id);
+    expect(ids).not.toContain("tasks/broker-phase-1.md");
+    const parent = m.gantt!.rows.find(
+      (r) => r.id === "tasks/broker-operator.md"
+    )!;
+    expect(parent.collapsed).toBe(true);
+    expect(parent.hasKids).toBe(true); // stays expandable while contracted
+  });
+});
+
+describe("layoutGantt — labels", () => {
+  const labelCfg: MapCfg = {
+    levels: [
+      { id: "t", from: "tasks", card: { title: "title", labels: ["status"] } },
+    ],
+    gantt: { start: "start", end: "due" },
+  };
+
+  const multiCfg: MapCfg = {
+    levels: [
+      {
+        id: "t",
+        from: "tasks",
+        card: { title: "title", labels: ["status", "area"] },
+      },
+    ],
+    gantt: { start: "start", end: "due" },
+  };
+
+  it("joins the card labels into one discreet run for the row title", () => {
+    const notes = [
+      mk("tasks/tagged.md", {
+        id: "t1",
+        title: "Tagged",
+        parentId: "",
+        status: "wip",
+        start: "2026-03-02",
+        due: "2026-03-20",
+      }),
+    ];
+    const g = gantt(labelCfg, notes);
+    expect(g.rows[0].labelText).toBe("wip");
+  });
+
+  it("joins multiple label fields with a middot separator", () => {
+    const notes = [
+      mk("tasks/multi.md", {
+        id: "t1",
+        title: "Multi",
+        parentId: "",
+        status: "wip",
+        area: "devops",
+        start: "2026-03-02",
+        due: "2026-03-20",
+      }),
+    ];
+    const g = gantt(multiCfg, notes);
+    expect(g.rows[0].labelText).toBe("wip · devops");
+  });
+
+  it("gives a dateless row its label text too", () => {
+    const notes = [
+      mk("tasks/dateless.md", {
+        id: "t1",
+        title: "Dateless",
+        parentId: "",
+        status: "someday",
+      }),
+    ];
+    const g = gantt(labelCfg, notes);
+    expect(g.rows[0].labelText).toBe("someday");
+  });
+
+  it("emits no label text when showLabels is false", () => {
+    const cfg: MapCfg = {
+      ...labelCfg,
+      gantt: { ...labelCfg.gantt!, showLabels: false },
+    };
+    const notes = [
+      mk("tasks/tagged.md", {
+        id: "t1",
+        title: "Tagged",
+        parentId: "",
+        status: "wip",
+        start: "2026-03-02",
+        due: "2026-03-20",
+      }),
+    ];
+    const g = gantt(cfg, notes);
+    expect(g.rows[0].labelText).toBe("");
+  });
+
+  it("leaves label text empty when no labels are configured", () => {
+    const g = gantt();
+    g.rows.forEach((r) => expect(r.labelText).toBe(""));
+  });
+});
+
+describe("statusColor", () => {
+  it("maps done-like statuses to green (case/space/hyphen insensitive)", () => {
+    for (const s of ["done", "Complete", " COMPLETED ", "closed", "shipped"])
+      expect(statusColor(s)).toBe("#2ecc71");
+  });
+
+  it("maps in-progress-like statuses to blue", () => {
+    for (const s of [
+      "in progress",
+      "in-progress",
+      "In   Progress",
+      "doing",
+      "active",
+      "wip",
+      "started",
+      "ongoing",
+    ])
+      expect(statusColor(s)).toBe("#3498db");
+  });
+
+  it("maps todo-like statuses to grey", () => {
+    for (const s of [
+      "todo",
+      "to do",
+      "to-do",
+      "planned",
+      "backlog",
+      "open",
+      "not started",
+      "new",
+      "pending",
+    ])
+      expect(statusColor(s)).toBe("#95a5a6");
+  });
+
+  it("returns null for unknown or missing statuses", () => {
+    expect(statusColor("whatever")).toBeNull();
+    expect(statusColor("")).toBeNull();
+    expect(statusColor(undefined)).toBeNull();
+    expect(statusColor(null)).toBeNull();
+  });
+});
+
+describe("layoutGantt — status colour on rows", () => {
+  it("colours bars/milestones by the row status", () => {
+    const g = gantt();
+    const dns = g.rows.find((r) => r.id === "tasks/client-dns.md")!; // done
+    const broker = g.rows.find((r) => r.id === "tasks/broker-operator.md")!; // in-progress
+    const kickoff = g.rows.find((r) => r.id === "tasks/kickoff.md")!; // todo (milestone)
+    expect(dns.color).toBe("#2ecc71");
+    expect(broker.color).toBe("#3498db");
+    expect(kickoff.color).toBe("#95a5a6");
+  });
+
+  it("falls back to the node colour when the status is unknown/missing", () => {
+    const cfg: MapCfg = {
+      levels: [
+        { id: "t", from: "tasks", color: "#123456", card: { title: "title" } },
+      ],
+      gantt: { start: "start", end: "due" },
+    };
+    const notes = [
+      mk("tasks/nostatus.md", {
+        title: "No status",
+        start: "2026-01-05",
+        due: "2026-01-25",
+      }),
+    ];
+    const g = gantt(cfg, notes);
+    expect(g.rows[0].color).toBe("#123456");
+  });
+
+  it("reads the status from a configured field name", () => {
+    const cfg: MapCfg = {
+      levels: [{ id: "t", from: "tasks", card: { title: "title" } }],
+      gantt: { start: "start", end: "due", status: "state" },
+    };
+    const notes = [
+      mk("tasks/s.md", {
+        title: "S",
+        state: "done",
+        start: "2026-01-05",
+        due: "2026-01-25",
+      }),
+    ];
+    const g = gantt(cfg, notes);
+    expect(g.rows[0].color).toBe("#2ecc71");
+  });
+});
+
+describe("layoutGantt — today marker", () => {
+  const build2 = (today?: number) => {
+    const { nodes, byLevel, vis } = build();
+    return layoutGantt(taskCfg, nodes, byLevel, vis, { today });
+  };
+
+  it("sets todayX when today falls within the axis range", () => {
+    const g = build2(parseDay("2026-06-15")!);
+    expect(g.todayX).not.toBeNull();
+    expect(g.todayX!).toBeGreaterThan(GANTT.labelWidth);
+  });
+
+  it("leaves todayX null when today is outside the axis range", () => {
+    expect(build2(parseDay("2030-01-01")!).todayX).toBeNull();
+    expect(build2(parseDay("2000-01-01")!).todayX).toBeNull();
+  });
+
+  it("leaves todayX null when no today is supplied", () => {
+    expect(build2(undefined).todayX).toBeNull();
+    expect(gantt().todayX).toBeNull();
+  });
+
+  it("leaves todayX null when the chart has no dated rows (no ticks)", () => {
+    const { nodes, byLevel, vis } = build(taskCfg, [
+      mk("tasks/a.md", { id: "a", title: "A", parentId: "", status: "todo" }),
+    ]);
+    const g = layoutGantt(taskCfg, nodes, byLevel, vis, {
+      today: parseDay("2026-06-15")!,
+    });
+    expect(g.ticks).toEqual([]);
+    expect(g.todayX).toBeNull();
   });
 });
 
@@ -265,6 +692,30 @@ describe("layoutGantt — axis", () => {
     expect(w.ticks[0].label).toBe("5 Jan");
   });
 
+  it("labels the year scale with plain years from Jan 1", () => {
+    const y = gantt({
+      ...taskCfg,
+      gantt: { ...taskCfg.gantt!, scale: "year" },
+    });
+    // data range 2025-12-01 .. 2026-08-16 -> 2025, 2026 (+ one past the end)
+    expect(y.ticks[0].label).toBe("2025");
+    expect(y.ticks.map((t) => t.label)).toContain("2026");
+    const bar = y.rows.find((r) => r.id === "tasks/broker-operator.md")!.bar!;
+    expect(bar.w).toBeCloseTo(68 * GANTT.dayPx.year, 6);
+  });
+
+  it("honours a ui ganttScale override over cfg.gantt.scale", () => {
+    const m = buildRenderModel(taskCfg, taskNotes, resolverFor(taskNotes), {
+      view: "gantt",
+      ganttScale: "year",
+    });
+    expect(m.gantt!.ticks[0].label).toBe("2025");
+    const back = buildRenderModel(taskCfg, taskNotes, resolverFor(taskNotes), {
+      view: "gantt",
+    });
+    expect(back.gantt!.ticks[0].label).toBe("Dec 2025");
+  });
+
   it("handles an empty map (no rows, no ticks, top-only bounds)", () => {
     const g = gantt(taskCfg, []);
     expect(g.rows).toEqual([]);
@@ -288,6 +739,147 @@ describe("layoutGantt — axis", () => {
     expect(() =>
       gantt({ ...taskCfg, gantt: { start: "start" } as never })
     ).toThrow(/gantt.*start.*end/i);
+  });
+});
+
+describe("layoutGantt — major period boundaries", () => {
+  const tick = (g: GanttModel, label: string) =>
+    g.ticks.find((t) => t.label === label)!;
+
+  it("month view: firmer line at each quarter start, not mid-quarter", () => {
+    const g = gantt(); // Dec 2025 .. Sep 2026
+    expect(tick(g, "Jan 2026").major).toBe(true); // Q1 start
+    expect(tick(g, "Apr 2026").major).toBe(true); // Q2 start
+    expect(tick(g, "Dec 2025").major).toBe(false);
+    expect(tick(g, "Feb 2026").major).toBe(false);
+  });
+
+  it("quarter view: firmer line at the year start (Q1) only", () => {
+    const q = gantt({
+      ...taskCfg,
+      gantt: { ...taskCfg.gantt!, scale: "quarter" },
+    });
+    expect(tick(q, "Q1 2026").major).toBe(true);
+    expect(tick(q, "Q4 2025").major).toBe(false);
+    expect(tick(q, "Q2 2026").major).toBe(false);
+  });
+
+  it("week view: firmer line on the first week of a new month", () => {
+    const notes = [
+      mk("tasks/span.md", {
+        id: "t",
+        title: "Span",
+        parentId: "",
+        status: "todo",
+        start: "2026-01-20",
+        due: "2026-02-18",
+      }),
+    ];
+    const w = gantt(
+      { ...taskCfg, gantt: { ...taskCfg.gantt!, scale: "week" } },
+      notes
+    );
+    expect(w.ticks[0].major).toBe(true); // first tick always opens a "new" month
+    const feb = w.ticks.find((t) => t.label.endsWith("Feb"))!;
+    expect(feb.major).toBe(true);
+    const midJan = w.ticks.filter((t) => t.label.endsWith("Jan"));
+    expect(midJan.slice(1).every((t) => t.major === false)).toBe(true);
+  });
+
+  it("year view: firmer line at the decade boundary", () => {
+    const notes = [
+      mk("tasks/dec.md", {
+        id: "t",
+        title: "Decade span",
+        parentId: "",
+        status: "todo",
+        start: "2019-06-01",
+        due: "2021-06-01",
+      }),
+    ];
+    const y = gantt(
+      { ...taskCfg, gantt: { ...taskCfg.gantt!, scale: "year" } },
+      notes
+    );
+    expect(tick(y, "2020").major).toBe(true);
+    expect(tick(y, "2019").major).toBe(false);
+    expect(tick(y, "2021").major).toBe(false);
+  });
+});
+
+describe("layoutGantt — bar tooltip", () => {
+  it("a bar row's tooltip carries title, date range, and status", () => {
+    const notes = [
+      mk("tasks/x.md", {
+        id: "t",
+        title: "Ship it",
+        parentId: "",
+        status: "in-progress",
+        start: "2026-03-02",
+        due: "2026-03-20",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    expect(g.rows[0].tooltip).toBe(
+      "Ship it\n2026-03-02 → 2026-03-20\nStatus: in-progress"
+    );
+  });
+
+  it("a milestone row's tooltip shows the single date", () => {
+    const notes = [
+      mk("tasks/m.md", {
+        id: "t",
+        title: "Launch",
+        parentId: "",
+        status: "todo",
+        due: "2026-04-01",
+      }),
+    ];
+    const g = gantt(taskCfg, notes);
+    expect(g.rows[0].tooltip).toBe("Launch\n2026-04-01\nStatus: todo");
+  });
+
+  it("a dateless, statusless row's tooltip is just the title", () => {
+    const notes = [
+      mk("tasks/bare.md", { id: "t", title: "Bare", parentId: "" }),
+    ];
+    const g = gantt(
+      {
+        levels: [{ id: "t", from: "tasks", card: { title: "title" } }],
+        gantt: { start: "start", end: "due" },
+      },
+      notes
+    );
+    expect(g.rows[0].tooltip).toBe("Bare");
+  });
+
+  it("carries progress and tags when present", () => {
+    const cfg: MapCfg = {
+      levels: [
+        {
+          id: "t",
+          from: "tasks",
+          card: { title: "title", progress: "progress", labels: ["area"] },
+        },
+      ],
+      gantt: { start: "start", end: "due" },
+    };
+    const notes = [
+      mk("tasks/x.md", {
+        id: "t",
+        title: "Ship it",
+        parentId: "",
+        status: "in-progress",
+        start: "2026-03-02",
+        due: "2026-03-20",
+        progress: 30,
+        area: "devops",
+      }),
+    ];
+    const g = gantt(cfg, notes);
+    expect(g.rows[0].tooltip).toBe(
+      "Ship it\n2026-03-02 → 2026-03-20\nStatus: in-progress\nProgress: 30%\nTags: devops"
+    );
   });
 });
 

--- a/test/kanban.test.ts
+++ b/test/kanban.test.ts
@@ -155,3 +155,162 @@ describe("buildRenderModel — kanban view", () => {
     expect(m.headers.map((h) => h.label)).toEqual(["done"]);
   });
 });
+
+// ---- two-level same-folder setup (mirrors the user's real roadmap vault) ----
+// Level 0: top-level tasks (where parentId == null), each has a status.
+// Level 1: subtasks (same folder, no where), mostly have NO status field.
+// Kanban groupBy: "status" must produce one column per distinct status value
+// PLUS a trailing "(none)" for statusless subtasks — all at distinct x positions.
+describe("buildRenderModel — kanban two-level same-folder", () => {
+  // Build a minimal but realistic replica: 3 parents (todo/in-progress/done) + 3 subtasks (no status).
+  const folder = "roadmap";
+  const sameFolder: import("../src/graph").NoteLike[] = [
+    // top-level tasks — have a status field (some "quoted" in the source YAML,
+    // but Obsidian's YAML parser strips quotes before we see the value)
+    mk(`${folder}/task-todo-1.md`, {
+      id: "t1",
+      title: "Todo task 1",
+      parentId: "",
+      status: "todo",
+    }),
+    mk(`${folder}/task-todo-2.md`, {
+      id: "t2",
+      title: "Todo task 2",
+      parentId: "",
+      status: "todo",
+    }),
+    mk(`${folder}/task-wip.md`, {
+      id: "t3",
+      title: "WIP task",
+      parentId: "",
+      status: "in-progress",
+    }),
+    mk(`${folder}/task-done.md`, {
+      id: "t4",
+      title: "Done task",
+      parentId: "",
+      status: "done",
+    }),
+    // subtasks — linked via parentId, NO status field → go to "(none)"
+    mk(`${folder}/sub-a.md`, { id: "s1", title: "Sub A", parentId: "t1" }),
+    mk(`${folder}/sub-b.md`, { id: "s2", title: "Sub B", parentId: "t3" }),
+    mk(`${folder}/sub-c.md`, { id: "s3", title: "Sub C", parentId: "t3" }),
+  ];
+
+  const sameFolderCfg: import("../src/graph").MapCfg = {
+    levels: [
+      {
+        id: "tasks",
+        from: folder,
+        where: { parentId: null }, // top-level tasks only
+        card: { title: "title", meta: ["status"] },
+      },
+      {
+        id: "subtasks",
+        from: folder, // SAME folder, no where → picks up the subtasks
+        card: { title: "title" },
+      },
+    ],
+    edges: [{ from: "tasks", to: "subtasks", via: "parentId" }],
+    kanban: { groupBy: "status" },
+    filter: ["status"],
+  };
+
+  it("produces 4 columns (todo/in-progress/done/none) — not stacked into one", () => {
+    const m = buildRenderModel(
+      { ...sameFolderCfg, view: "kanban" },
+      sameFolder,
+      resolverFor(sameFolder)
+    );
+    expect(m.view).toBe("kanban");
+    // 3 status columns + 1 (none) column for subtasks without status
+    expect(m.headers.map((h) => h.label)).toContain("todo");
+    expect(m.headers.map((h) => h.label)).toContain("in-progress");
+    expect(m.headers.map((h) => h.label)).toContain("done");
+    expect(m.headers.map((h) => h.label)).toContain("(none)");
+    expect(m.headers.length).toBe(4);
+  });
+
+  it("all 7 nodes are placed and none is lost in the (none) bucket", () => {
+    const m = buildRenderModel(
+      { ...sameFolderCfg, view: "kanban" },
+      sameFolder,
+      resolverFor(sameFolder)
+    );
+    expect(m.nodes.length).toBe(7);
+    const noneHeader = m.headers.find((h) => h.label === "(none)")!;
+    expect(noneHeader.count).toBe(3); // three statusless subtasks
+  });
+
+  it("each column header sits at a distinct x — columns are side-by-side not stacked", () => {
+    const m = buildRenderModel(
+      { ...sameFolderCfg, view: "kanban" },
+      sameFolder,
+      resolverFor(sameFolder)
+    );
+    const xs = m.headers.map((h) => h.x);
+    // all x values must be unique (no two columns share the same horizontal position)
+    expect(new Set(xs).size).toBe(xs.length);
+    // and they must be strictly increasing (left-to-right order)
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+  });
+
+  it("nodes in different columns have different x coordinates", () => {
+    const m = buildRenderModel(
+      { ...sameFolderCfg, view: "kanban" },
+      sameFolder,
+      resolverFor(sameFolder)
+    );
+    // build a map: nodeId -> column label (via the header x)
+    const xToLabel = Object.fromEntries(m.headers.map((h) => [h.x, h.label]));
+    const byColumn: Record<string, string[]> = {};
+    m.nodes.forEach((n) => {
+      const col = xToLabel[n.x] ?? `x=${n.x}`;
+      (byColumn[col] = byColumn[col] || []).push(n.id);
+    });
+    // todo nodes must NOT share x with in-progress or done nodes
+    const todoXs = m.nodes
+      .filter((n) => xToLabel[n.x] === "todo")
+      .map((n) => n.x);
+    const wipXs = m.nodes
+      .filter((n) => xToLabel[n.x] === "in-progress")
+      .map((n) => n.x);
+    const doneXs = m.nodes
+      .filter((n) => xToLabel[n.x] === "done")
+      .map((n) => n.x);
+    const noneXs = m.nodes
+      .filter((n) => xToLabel[n.x] === "(none)")
+      .map((n) => n.x);
+    // each status group must have at least one node, all at the same x, distinct from others
+    expect(todoXs.length).toBeGreaterThan(0);
+    expect(wipXs.length).toBeGreaterThan(0);
+    expect(doneXs.length).toBeGreaterThan(0);
+    expect(noneXs.length).toBeGreaterThan(0);
+    const uniqueX = (arr: number[]) => (new Set(arr).size === 1 ? arr[0] : NaN);
+    const tx = uniqueX(todoXs),
+      wx = uniqueX(wipXs),
+      dx = uniqueX(doneXs),
+      nx = uniqueX(noneXs);
+    expect([tx, wx, dx, nx].every((v) => !isNaN(v))).toBe(true); // each column has one x
+    expect(new Set([tx, wx, dx, nx]).size).toBe(4); // all four x values are distinct
+  });
+
+  it("subtasks with no status field land in (none), not in a status column", () => {
+    const m = buildRenderModel(
+      { ...sameFolderCfg, view: "kanban" },
+      sameFolder,
+      resolverFor(sameFolder)
+    );
+    const noneX = m.headers.find((h) => h.label === "(none)")!.x;
+    const subtaskIds = [
+      `${folder}/sub-a.md`,
+      `${folder}/sub-b.md`,
+      `${folder}/sub-c.md`,
+    ];
+    subtaskIds.forEach((id) => {
+      const node = m.nodes.find((n) => n.id === id)!;
+      expect(node).toBeDefined();
+      expect(node.x).toBe(noneX);
+    });
+  });
+});

--- a/test/visibility.test.ts
+++ b/test/visibility.test.ts
@@ -191,6 +191,156 @@ describe("computeVisible — filters", () => {
   });
 });
 
+describe("computeVisible — filterKeepsHierarchy", () => {
+  // pm-task-shaped: parent carries the tag, subtasks carry their own (or none)
+  const hierCfg: MapCfg = {
+    levels: [
+      {
+        id: "top",
+        from: "tasks",
+        where: { parentId: null },
+        card: { title: "title" },
+      },
+      { id: "sub", from: "tasks", card: { title: "title" } },
+    ],
+    edges: [{ from: "top", to: "sub", via: "parentId" }],
+    filter: ["tags"],
+    filterKeepsHierarchy: true,
+  };
+  const hierNotes = [
+    mk("tasks/rearch.md", {
+      id: "p-rearch",
+      title: "Front end rearchitecture",
+      parentId: "",
+      tags: ["product"],
+    }),
+    mk("tasks/rearch-a11y.md", {
+      id: "t-a11y",
+      title: "A11y pass",
+      parentId: "p-rearch",
+      tags: ["frontend"],
+    }),
+    mk("tasks/rearch-tokens.md", {
+      id: "t-tokens",
+      title: "Design tokens",
+      parentId: "p-rearch",
+    }),
+    mk("tasks/dns.md", {
+      id: "t-dns",
+      title: "DNS cutover",
+      parentId: "",
+      tags: ["devops"],
+    }),
+  ];
+  const build = () => {
+    const { nodes, byLevel } = collectNodes(hierCfg, hierNotes);
+    buildEdges(hierCfg, nodes, byLevel, resolverFor(hierNotes));
+    return nodes;
+  };
+
+  it("a matching parent keeps its subtasks even when they don't match", () => {
+    const vis = computeVisible(
+      build(),
+      new Set(),
+      { tags: new Set(["product"]) },
+      hierCfg
+    );
+    expect(vis.has("tasks/rearch.md")).toBe(true);
+    expect(vis.has("tasks/rearch-a11y.md")).toBe(true); // wrong tag, kept
+    expect(vis.has("tasks/rearch-tokens.md")).toBe(true); // no tag, kept
+    expect(vis.has("tasks/dns.md")).toBe(false);
+  });
+
+  it("a matching child keeps its non-matching parent as context", () => {
+    const vis = computeVisible(
+      build(),
+      new Set(),
+      { tags: new Set(["frontend"]) },
+      hierCfg
+    );
+    expect(vis.has("tasks/rearch-a11y.md")).toBe(true);
+    expect(vis.has("tasks/rearch.md")).toBe(true); // context, not a match
+    expect(vis.has("tasks/rearch-tokens.md")).toBe(true); // no tags: unconstrained
+    expect(vis.has("tasks/dns.md")).toBe(false);
+  });
+
+  it("collapse still hides the subtree under hierarchy-aware filters", () => {
+    const vis = computeVisible(
+      build(),
+      new Set(["tasks/rearch.md"]),
+      { tags: new Set(["product"]) },
+      hierCfg
+    );
+    expect(vis.has("tasks/rearch.md")).toBe(true);
+    expect(vis.has("tasks/rearch-a11y.md")).toBe(false);
+    expect(vis.has("tasks/rearch-tokens.md")).toBe(false);
+  });
+
+  it("tolerates empty selections, a missing filter list, and stale collapse ids", () => {
+    const nodes = build();
+    // selection present but no values -> every node positively matches
+    const all = computeVisible(nodes, new Set(), { tags: new Set() }, hierCfg);
+    expect(all.size).toBe(Object.keys(nodes).length);
+    // no `filter` in the cfg at all -> nothing is constrained
+    const noFilter: MapCfg = {
+      levels: [{ id: "t", from: "tasks", card: { title: "title" } }],
+      filterKeepsHierarchy: true,
+    };
+    const flat = collectNodes(noFilter, hierNotes);
+    const vis = computeVisible(
+      flat.nodes,
+      new Set(["tasks/ghost.md"]), // stale collapse id: ignored
+      { tags: new Set(["product"]) },
+      noFilter
+    );
+    expect(vis.size).toBe(Object.keys(flat.nodes).length);
+  });
+
+  it("survives a primary-parent cycle under collapse", () => {
+    const cycCfg: MapCfg = {
+      levels: [
+        { id: "a", from: "a", card: { title: "title" } },
+        { id: "b", from: "b", card: { title: "title" } },
+      ],
+      edges: [
+        { from: "a", to: "b", via: "up" },
+        { from: "b", to: "a", via: "down" },
+      ],
+      filterKeepsHierarchy: true,
+    };
+    const notes = [
+      mk("a/A.md", { title: "A", down: "B" }),
+      mk("b/B.md", { title: "B", up: "A" }),
+    ];
+    const { nodes, byLevel } = collectNodes(cycCfg, notes);
+    buildEdges(cycCfg, nodes, byLevel, resolverFor(notes));
+    const vis = computeVisible(
+      nodes,
+      new Set(["a/A.md", "b/B.md"]),
+      {},
+      cycCfg
+    );
+    // in a 2-cycle each node sits in the other's subtree: collapsing both
+    // hides both, and the walk terminates instead of looping
+    expect(vis.size).toBe(0);
+  });
+
+  it("without the flag the strict behaviour is unchanged", () => {
+    const strict: MapCfg = { ...hierCfg, filterKeepsHierarchy: false };
+    const { nodes, byLevel } = collectNodes(strict, hierNotes);
+    buildEdges(strict, nodes, byLevel, resolverFor(hierNotes));
+    const vis = computeVisible(
+      nodes,
+      new Set(),
+      { tags: new Set(["product"]) },
+      strict
+    );
+    expect(vis.has("tasks/rearch.md")).toBe(true);
+    expect(vis.has("tasks/rearch-a11y.md")).toBe(false);
+    expect(vis.has("tasks/dns.md")).toBe(false);
+  });
+});
+
 describe("passesFilters — unit", () => {
   const cfg: MapCfg = {
     levels: [{ id: "x", from: "x" }],


### PR DESCRIPTION
## What

- **Gantt density toggle** (`compact` / `comfortable`): comfortable scales up rows and fonts for reading from a distance in presentations. Configurable via `gantt: { density }` and switchable from the toolbar's Density chips.
- Model-driven gantt metrics: one density number drives row height, fonts, bars, indent (renderer reads them instead of hardcoding).
- Vertical centering of gantt row labels and bar titles at any font size.
- Kanban, visibility, and export refinements, with tests.

## Verification

- `npm test` → 326 passing, 100% coverage
- `npm run build` clean (typecheck + esbuild both targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)