### PR TITLE
docs: sync README + in-app help with the plugin's current features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Leveled left-to-right mind maps from note frontmatter links, with **two adapters
 - `src/graph.ts` — re-exporting barrel over `src/core/`; every import path goes through it.
 - `src/causal.ts` — **pure causal-map core.** Imports only from `graph.ts`. Signed-edge collection, cycle detection, loop polarity, force-directed layout. Same rules as the core: host-free, 100% covered.
 - `src/render/` — **shared SVG renderer** (`renderer.ts` draws a `RenderModel` into an injected document/SVG root for all three views; `panzoom.ts` owns pan/zoom/fit). The only DOM code outside the adapters; coverage-excluded like them, but lint-covered and bundled into both builds.
-- `src/obsidian/main.ts` — **Obsidian adapter** (with `src/obsidian/causal.ts` for ` ```causalmap ` blocks); only these files import `obsidian`. Owns host I/O (vault read, resolver, code-block processor, YAML write-back), toolbar/state wiring, exports, and the note `Modal`. Builds `main.js`.
+- `src/obsidian/` — **Obsidian adapter.** `main.ts` (` ```mindmap ` blocks), `causal.ts` (` ```causalmap ` blocks), `modals.ts` (prompt/confirm/help/note dialogs) — the only files that import `obsidian` — plus `svg.ts`, a host-free element helper. Owns host I/O (vault read, resolver, code-block processor, YAML write-back), toolbar/state wiring, and exports. Builds `main.js`.
 - `src/vscode/` — **VS Code adapter.** `extension.ts` (host: reads workspace markdown, runs `buildRenderModel`, posts the `RenderModel`), `webview.ts` (bootstrap: shared renderer + pan/zoom + click-to-open). Builds `dist/extension.js` + `dist/webview.js`.
 - `styles.css` — Obsidian theming via CSS variables. (VS Code styling is inline in the webview HTML shell, using `--vscode-*` vars.)
 - `test/` — vitest, exercising the core through plain `NoteLike` data (host-agnostic).
@@ -46,3 +46,4 @@ git push --follow-tags
 - **TDD on the core.** Test-first for anything under `src/core/` (via the `src/graph.ts` barrel): red, watch it fail, green. Pre-commit and pre-push hooks run typecheck + tests.
 - DOM code in `main.ts` and `src/render/` is validated by build + manual Obsidian check (not unit-tested; the established split is "pure logic is tested, rendering is not").
 - Mark deliberate simplifications with a `// ponytail:` comment naming the ceiling.
+- **User-facing docs live in three places; change them together.** A new config key or toolbar control means updating `README.md` (the reference), the `HELP` string in `src/obsidian/modals.ts` (the in-app cheat sheet — the plugin can't read the README at runtime), and `examples/README.md` when a demo starts exercising it. The help modal drifting behind the README is the recurring failure here.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![coverage](https://raw.githubusercontent.com/kikocastro/markdown-mindmap/gh-pages/badges/coverage.svg)](https://github.com/kikocastro/markdown-mindmap/actions/workflows/test.yml)
 
-An [Obsidian](https://obsidian.md) plugin that renders configurable mind maps (leveled, left-to-right trees) **live from your notes' frontmatter links**. Each map is a single fenced ` ```mindmap ` code block, so you can drop as many maps as you like anywhere in your vault. There is no separate data file to keep in sync: the tree is rebuilt from your notes every time you open it.
+**Draw your notes, live.** Markdown Mindmap reads the links you already keep in your notes' frontmatter and renders them — as a leveled mind map, a gantt chart, a kanban board, or a causal-loop diagram. There is no second copy of the data to maintain: every map is rebuilt from your notes each time you open it, so the picture can't drift from the source.
 
-Point it at some folders, tell it which frontmatter field links each note to its parent, and it draws the graph: a column per level, curved edges, hover to highlight a node's lineage, click to open the note, collapse/expand subtrees, filter, and search.
+A map is one fenced code block, so you can drop as many as you like anywhere in your vault. There are two kinds:
 
-It ships as **two adapters over one shared core** (`src/graph.ts`): the **Obsidian plugin** (the full experience described below, rendered inline in a note) and a **VS Code extension** (a command opens the map in a panel — see [VS Code](#vs-code)). The feature list below describes the Obsidian plugin; the VS Code adapter is intentionally minimal for now (render + pan/zoom + click-to-open).
+- ` ```mindmap ` — a leveled left-to-right tree, switchable between **map**, **gantt**, and **kanban** views of the same notes.
+- ` ```causalmap ` — a **causal-loop diagram** for systems thinking, with feedback loops detected automatically.
+
+Point a block at some folders, name the frontmatter field that links each note to its parent, and it draws the graph.
 
 ## Screenshots
 
@@ -24,60 +27,33 @@ It ships as **two adapters over one shared core** (`src/graph.ts`): the **Obsidi
 | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | ![Causal map overview with loop and type rails](assets/screenshot-causalmap-overview.png) | ![Causal map spotlighting the morale loop](assets/screenshot-causalmap-loop.png) |
 
-## Features
+## What you get
 
-- **Live from frontmatter.** Folders become columns; frontmatter links become edges. Add or remove a note and the map updates.
-- **Three views over one dataset.** The same block renders as a mind **map**, a **gantt** (bars by start/due, progress fill, status colours, a _today_ marker, milestone diamonds), or a **kanban** board (columns by any field) — switch from the toolbar, filters and search apply everywhere.
-- **Per-level card design.** Pick which fields show as title / subtitle / meta per level; cards auto-size to their content.
-- **Edges from links.** A `[[wikilink]]`, plain title, basename, list, or nested field (`customFields.serves`) on either end of an edge.
-- **Secondary (dashed) links.** Mark cross-links that should draw dashed and stay out of the layout spine (e.g. "also relates to").
-- **Bar charts & progress bars.** Render a 0–100 field as a progress bar, or a list field as a stacked count-by-category bar.
-- **Multi-select filters and saved views.** Toggle-chip filters per property (OR within a property, AND across), then save named filter combinations back into the map block. Each saved view also remembers which subtrees are collapsed and which view type it opened in, and the one you pick is remembered across Obsidian restarts.
-- **Strict or hierarchy-aware filtering.** By default a filtered-out note takes its subtree with it; set `filterKeepsHierarchy: true` to keep matches in context — their subtasks ride along and their ancestors stay visible.
-- **Export.** Save the current view next to the note as a standalone HTML file or an editable Excalidraw drawing.
-- **Search highlight.** A search box that spotlights matching cards and dims the rest.
-- **Collapse / expand** any subtree, focus a node's lineage/subtree, **pan / zoom / fit / fullscreen**; click a card for a dialog with its linked parents/siblings/children, optional properties, and the rendered note.
-- **Theme-aware.** Uses Obsidian CSS variables, so it follows your light/dark theme.
-
-## How it works
-
-A map is a list of **levels**. Each level reads notes from a `from:` folder and becomes a **column** (left to right, in the order you list them). **Edges** connect levels: an edge says _"notes in the child level point up to a note in the parent level via frontmatter field X"_.
-
-```
- LEVEL 0          LEVEL 1              LEVEL 2
- ┌──────────┐     ┌──────────────┐     ┌────────────┐
- │  Goal A  │────▶│  Project 1   │────▶│   Task …    │
- │          │──┐  └──────────────┘     └────────────┘
- └──────────┘  │  ┌──────────────┐     ┌────────────┐
-               └─▶│  Project 2   │────▶│   Task …    │
-                  └──────────────┘     └────────────┘
-        edge: project.goal=[[Goal A]]    edge: task.project=[[Project 1]]
-```
+- **Four pictures from one set of notes** — mind map, gantt, kanban, and causal-loop diagram, all driven by frontmatter you already write.
+- **Cards you design per level** — choose which fields become the title, subtitle, meta line, progress bar, category bar, or coloured pills. Cards size themselves to fit.
+- **Filters, search, and saved views** — multi-select chips per property, a search box that spotlights matches, and named filter combinations saved back into the block.
+- **Navigation that respects the tree** — hover to light up a node's whole lineage, collapse any subtree, focus a branch, or open a card for its linked parents, siblings, and children.
+- **Export** — save the current view as a standalone HTML file or an editable Excalidraw drawing.
+- **Native-feeling** — themed with Obsidian's own CSS variables, so it follows your light/dark theme.
+- **Two hosts** — everything above is the Obsidian plugin; a [VS Code extension](#vs-code) renders ` ```mindmap ` blocks from the same core, in a panel.
 
 ## Install
 
 ### Community plugins (recommended)
 
-[Markdown Mindmap](https://community.obsidian.md/plugins/markdown-mindmap) is in the Obsidian community plugin store:
-
-1. **Settings → Community plugins → Browse**.
-2. Search **"Markdown Mindmap"**, **Install**, then **Enable**.
-
-Updates arrive through Obsidian's normal plugin-update flow.
-
-### Manual (local testing / latest build)
-
-1. Get the three build files (`main.js`, `manifest.json`, `styles.css`) — either from a [Release](../../releases) or by building from source (`npm install && npm run build`).
-2. Copy them into `<your-vault>/.obsidian/plugins/markdown-mindmap/`.
-3. Reload Obsidian, then **Settings → Community plugins → enable "Markdown Mindmap"**.
+[Markdown Mindmap](https://community.obsidian.md/plugins/markdown-mindmap) is in the Obsidian community plugin store: **Settings → Community plugins → Browse**, search **"Markdown Mindmap"**, **Install**, then **Enable**. Updates arrive through Obsidian's normal plugin-update flow.
 
 ### BRAT
 
-Once a release is published, install with [BRAT](https://github.com/TfTHacker/obsidian42-brat): _Add beta plugin_ → `kikocastro/markdown-mindmap`. BRAT-managed plugins also survive Obsidian Sync, unlike a hand-copied folder.
+For pre-release builds, use [BRAT](https://github.com/TfTHacker/obsidian42-brat): _Add beta plugin_ → `kikocastro/markdown-mindmap`. BRAT-managed plugins also survive Obsidian Sync, unlike a hand-copied folder.
+
+### Manual
+
+Get the three build files (`main.js`, `manifest.json`, `styles.css`) from a [Release](../../releases) or by building from source (`npm install && npm run build`), copy them into `<your-vault>/.obsidian/plugins/markdown-mindmap/`, reload Obsidian, and enable the plugin under **Settings → Community plugins**.
 
 ## Quick start
 
-Put this in any note (Reading view or Live Preview):
+Put this in any note and open it in Reading view or Live Preview:
 
 ````markdown
 ```mindmap
@@ -102,101 +78,72 @@ filter: [status]
 ```
 ````
 
-> A runnable copy of this map, with sample notes, lives in [`examples/mindmap-demo/`](examples/mindmap-demo). Copy that folder into your vault root and open `Mindmap demo.md`. A second, richer tree — an Opportunity Solution Tree with interview-quote subtitles and a saved view — lives in [`examples/ost-demo/`](examples/ost-demo). See [`examples/README.md`](examples/README.md) for what each demo exercises.
+Three folders become three columns; the `goal:` and `project:` frontmatter fields become the arrows between them; `status` becomes a row of filter chips.
 
-## Configuration reference
+Two runnable demos ship with the repo — copy either folder into your vault root and open its note:
 
-**Top level**
+- [`examples/mindmap-demo/`](examples/mindmap-demo) — vision → areas → features → tasks, exercising per-level colours, a reverse edge, category bars, and a dashed secondary link.
+- [`examples/ost-demo/`](examples/ost-demo) — an Opportunity Solution Tree with interview-quote subtitles and a saved view.
 
-| Key                    | Type            | Meaning                                                                                                                                                    |
-| ---------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`                | string          | Heading in the toolbar.                                                                                                                                    |
-| `height`               | number          | Component height in px (default `900`).                                                                                                                    |
-| `view`                 | string          | Initial view: `map` (default), `gantt`, or `kanban`.                                                                                                       |
-| `levels`               | list            | Columns, left to right. **Required.**                                                                                                                      |
-| `edges`                | list            | Parent → child links between levels.                                                                                                                       |
-| `gantt`                | map             | Gantt view config (see [Gantt & kanban views](#gantt--kanban-views)). Configuring it adds the view to the switcher.                                        |
-| `kanban`               | map             | Kanban view config (same section). Configuring it adds the view to the switcher.                                                                           |
-| `filter`               | list of strings | Frontmatter properties exposed as multi-select chip filters.                                                                                               |
-| `filterLabels`         | map             | Rename a filter group's heading, e.g. `{ customFields.quarters: Quarter }`. Unlisted properties keep their raw name.                                       |
-| `filterKeepsHierarchy` | boolean         | Default `false` (strict): a filtered-out note hides itself **and** its subtree. `true` keeps context (below).                                              |
-| `layout`               | map             | Override card/column sizing (below). All keys optional.                                                                                                    |
-| `properties`           | boolean         | When `true`, the note dialog shows all frontmatter as a table above the rendered note.                                                                     |
-| `views`                | list            | Saved views (filters + collapse + view mode), managed by the toolbar's saved-view controls.                                                                |
-| `activeView`           | string          | Name of the saved view to re-select on render. Written by the toolbar when you pick one, so the choice survives an Obsidian restart; cleared by **Reset**. |
+See [`examples/README.md`](examples/README.md) for what each one demonstrates.
 
-**`layout`** (all optional, defaults shown)
+## How it works
 
-| Key          | Default | Meaning                                                                                                                          |
-| ------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `cardWidth`  | `270`   | Card width in px.                                                                                                                |
-| `cardHeight` | `44`    | **Minimum** card height in px. Cards auto-size to their content (title lines, sub, meta, bar, labels); this only sets the floor. |
-| `columnGap`  | `150`   | Horizontal gap between columns.                                                                                                  |
-| `rowGap`     | `12`    | Vertical gap between stacked cards.                                                                                              |
-| `top`        | `64`    | Top margin before the first card.                                                                                                |
-| `titleLines` | `2`     | Title lines shown before truncating. Set `3` to allow longer titles; cards grow to fit automatically.                            |
-| `subLines`   | `1`     | Subtitle (`sub`) lines shown before truncating. Set `2`+ to wrap a long subtitle onto multiple lines; cards grow to fit.         |
+A map is a list of **levels**. Each level reads notes from a `from:` folder and becomes a **column**, left to right in the order you list them. **Edges** connect levels: an edge says _"notes in the child level point up to a note in the parent level via frontmatter field X"_.
 
-**Each level**
+```
+ LEVEL 0          LEVEL 1              LEVEL 2
+ ┌──────────┐     ┌──────────────┐     ┌────────────┐
+ │  Goal A  │────▶│  Project 1   │────▶│   Task …    │
+ │          │──┐  └──────────────┘     └────────────┘
+ └──────────┘  │  ┌──────────────┐     ┌────────────┐
+               └─▶│  Project 2   │────▶│   Task …    │
+                  └──────────────┘     └────────────┘
+        edge: project.goal=[[Goal A]]    edge: task.project=[[Project 1]]
+```
 
-| Key     | Type       | Meaning                                                                                                                                                                                                                                              |
-| ------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`    | string     | Unique id, referenced by edges. **Required.**                                                                                                                                                                                                        |
-| `from`  | string     | Folder to read notes from (recursive). **Required.**                                                                                                                                                                                                 |
-| `label` | string     | Column header.                                                                                                                                                                                                                                       |
-| `color` | hex string | Column / card-border colour. Defaults cycle the [flatuicolors _defo_](https://flatuicolors.com/palette/defo) palette.                                                                                                                                |
-| `where` | map        | Keep only notes whose frontmatter matches a value, e.g. `{ horizon: now }` to use only drivers with `horizon: now`, or `{ parentId: null }` to keep top-level notes (a `null` target matches null, empty, **or** missing). Multiple keys are AND-ed. |
-| `card`  | map        | Which fields render on the card (below).                                                                                                                                                                                                             |
-
-**Each card**
-
-All card field values are frontmatter property names. Dotted paths work everywhere (`customFields.serves`, `nested.key`).
-
-| Key        | Type             | Renders                                                                                                                                                                             |
-| ---------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`    | field            | Bold title (falls back to the file name).                                                                                                                                           |
-| `sub`      | field            | Subtitle line.                                                                                                                                                                      |
-| `meta`     | list of fields   | A muted `·`-joined line.                                                                                                                                                            |
-| `progress` | field (0–100)    | A progress bar.                                                                                                                                                                     |
-| `bars`     | field **or** map | A stacked count-by-category bar (below).                                                                                                                                            |
-| `labels`   | list of fields   | Small colored value pills along the card's bottom strip, one per field (e.g. `[kind, horizon, stage]`). Empty/missing fields drop out; pills that don't fit on one row are skipped. |
-
-**`bars`** — either a field name (string) or a map:
-
-| Key        | Type                | Meaning                                                                                                                                            |
-| ---------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `field`    | field               | The list field to count. **Required.**                                                                                                             |
-| `category` | `parens` \| `value` | How to derive each category. `parens` (default): text in trailing parens, else the value (`"Acme (client)"` → `client`). `value`: the whole value. |
-| `colors`   | map                 | `category → hex`. Categories not listed cycle the auto palette. Omit to use the built-in `client`/`prospect`/`trial`/`customer` defaults.          |
-
-`bars: demand` is shorthand for `bars: { field: demand, category: parens }`.
-
-**Each edge**
-
-| Key         | Type     | Meaning                                                                                                                                                          |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`      | level id | Parent level.                                                                                                                                                    |
-| `to`        | level id | Child level.                                                                                                                                                     |
-| `via`       | field    | The frontmatter field holding the link. By default it lives on the **`to`** notes and points up to a **`from`** note. Dotted paths work (`customFields.serves`). |
-| `reverse`   | bool     | Set `true` when the field lives on the **`from`** notes and points down (e.g. a `serves:` list).                                                                 |
-| `secondary` | bool     | Draw the edge **dashed** and keep it out of the layout spine (for "also relates to" cross-links).                                                                |
+By default the linking field lives on the **child** notes and points up. Set `reverse: true` when it lives on the parent and points down (a `serves:` list, say). Mark an edge `secondary: true` and it draws **dashed** and stays out of the layout spine — the way to show "also relates to" without distorting the tree.
 
 ### How links resolve
 
-A `via` value is matched, in order, against: Obsidian's own link resolution (`[[wikilink]]`), then the target's **basename**, then its `title` frontmatter, then its `id` frontmatter (so pm-style `parentId: p-broker-operator` hierarchies link up). A value may be a single link or a list. A note's **first non-secondary** parent is its layout parent (single-parent tree); any extra parents still draw edges.
+A `via` value is matched, in order, against Obsidian's own link resolution (`[[wikilink]]`), then the target's **basename**, then its `title` frontmatter, then its `id` frontmatter — so pm-style `parentId: p-broker-operator` hierarchies link up. A value may be a single link or a list.
+
+A note's **first non-secondary** parent is its layout parent, keeping the drawing a single-parent tree; any extra parents still draw their edges.
 
 ### How filters treat the hierarchy
 
-A filter only constrains notes that **have** the property — a note missing it is never filtered out by that chip. What differs is what happens to the notes around a match:
+A filter only constrains notes that **have** the property — a note missing it is never hidden by that chip. What differs is what happens to the notes around a match:
 
-- **Strict (default).** A note that fails the filter hides itself and its whole primary subtree. Good for "show me only the devops tasks", where a parent that isn't devops shouldn't drag its children in.
-- **`filterKeepsHierarchy: true`.** A match keeps its context: its primary **subtree rides along** (a matching epic still shows its subtasks, whatever their own status) and its **ancestors stay visible** as scaffolding. Good for a roadmap where you want the tree shape intact around the hits.
+- **Strict (default).** A note that fails the filter hides itself and its whole primary subtree. Right for "show me only the devops tasks", where a parent that isn't devops shouldn't drag its children along.
+- **`filterKeepsHierarchy: true`.** A match keeps its context: its subtree rides along (a matching epic still shows its subtasks, whatever their own status) and its ancestors stay visible as scaffolding. Right for a roadmap where the tree shape matters.
 
-Collapse always applies last, so a contracted subtree stays hidden under either mode.
+Collapse applies last either way, so a contracted subtree stays hidden.
 
-## Gantt & kanban views
+### A fuller example
 
-The same collected + filtered tree can render as a **gantt** or a **kanban** board. Add the config block(s) and a view switcher appears in the toolbar; set `view:` to make one the default. Filters, search, collapse, and saved views apply in every view — a saved view pins **filters + view mode**, so you can keep e.g. a "devops · gantt" view one click away.
+A product strategy tree using per-level colours, secondary dashed links, category bars, and progress bars:
+
+````markdown
+```mindmap
+title: North Star → Drivers → Opportunities → Roadmap
+height: 860
+properties: true
+levels:
+  - { id: northstar, label: NORTH STAR,   from: strategy/north-star,   color: "#1abc9c", card: { title: title, sub: metric } }
+  - { id: drivers,   label: DRIVERS,       from: strategy/drivers,      color: "#9b59b6", card: { title: title, sub: metric } }
+  - { id: opps,      label: OPPORTUNITIES, from: strategy/opportunities, color: "#e67e22", card: { title: title, labels: [kind, horizon], bars: demand } }
+  - { id: roadmap,   label: ROADMAP,       from: strategy/roadmap,      color: "#e74c3c", where: { parentId: null }, card: { title: title, meta: [status], progress: progress } }
+edges:
+  - { from: drivers, to: opps,    via: ladders-to }
+  - { from: opps,    to: roadmap, via: serves }
+  - { from: opps,    to: roadmap, via: alsoServes, secondary: true }   # dashed
+filter: [horizon, kind, status]
+```
+````
+
+## The three views
+
+One ` ```mindmap ` block can draw its notes three ways. Add a `gantt:` or `kanban:` config and a **View** switcher appears in the toolbar; set `view:` to choose which one opens by default. Filters, search, and collapse are applied _before_ layout, so they behave identically in all three — and a saved view pins the filters **and** the view type, letting you keep a "devops · gantt" one click away.
 
 ````markdown
 ```mindmap
@@ -218,132 +165,27 @@ filter: [status, tags]
 ```
 ````
 
-**`gantt`** — field names are frontmatter properties, like everything else:
+**Map** is the default: a column per level, curved edges, cards centred on their children.
 
-| Key           | Type                                     | Meaning                                                                                                                                                  |
-| ------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `start`       | field                                    | Start date (ISO, e.g. `2026-06-09`). **Required.**                                                                                                       |
-| `end`         | field                                    | End/due date. **Required.**                                                                                                                              |
-| `progress`    | field (0–100)                            | Bar fill. Defaults to the card's `progress` field.                                                                                                       |
-| `status`      | field                                    | Field driving the bar/milestone colour (default `status`). See the status colours below.                                                                 |
-| `scale`       | `week` \| `month` \| `quarter` \| `year` | Axis tick unit (default `month`). Also switchable from the toolbar's Scale chips.                                                                        |
-| `density`     | `compact` \| `comfortable`               | Default `compact`. `comfortable` scales up rows and fonts for reading from a distance (presentations). Also switchable from the toolbar's Density chips. |
-| `sortByStart` | bool                                     | Default `true`: rows sort by crescent start date (dateless last). `false` restores the raw tree/path order.                                              |
-| `groupRows`   | bool                                     | Default `true`: rows follow the tree order with subtasks indented under parents. `false`: flat path order.                                               |
-| `showLabels`  | bool                                     | Default `true`: the card's `labels`, `·`-joined, on a discreet second line under the row title. `false` drops them for a barer chart.                    |
+**Gantt** lays the same tree out against a time axis. Rows run from `start` to `end` with a progress fill; a task whose dates are equal — or that has only one of them — becomes a **milestone diamond**, and a task with neither gets a plain row. Bars take their colour from the note's `status`, matched case-insensitively, with the spaced and hyphenated spellings of each both recognised:
 
-Rows render as bars from `start` to `end` with a progress fill. A task whose `start` equals its `end` (or that has only one of the two) renders as a **milestone diamond**. Tasks with neither date get a plain row. Click a row to open the note; hover one for a native tooltip with the full title, date range, status, progress, and tags. A vertical **today** marker is drawn when the current date falls inside the charted range.
+- **green** — `done`, `complete`, `completed`, `closed`, `shipped`
+- **blue** — `in progress`, `in-progress`, `doing`, `active`, `wip`, `started`, `ongoing`
+- **grey** — `todo`, `to do`, `to-do`, `planned`, `backlog`, `open`, `not started`, `new`, `pending`
 
-`sortByStart` sorts _within_ the hierarchy: siblings (and roots) are ordered by start date, but children stay grouped under their parent — the tree is never flattened. Nested items can be contracted/expanded with a per-row toggle, sharing the map view's collapse state, so saved views' collapsed lists apply here too. The toolbar's **show subtasks** chip (under **Rows**) expands/contracts every parent row at once; it's on by default, so the gantt opens with nested rows showing.
+Anything else — or a missing status — falls back to the level's colour. A vertical **today** marker appears when the current date is in range, and hovering a row shows its title, dates, status, progress, and tags.
 
-**Status colours.** Bars and milestones colour themselves from the `status` field, matched case- and space-insensitively: green for `done` / `complete` / `completed` / `closed` / `shipped`, blue for `in progress` / `in-progress` / `doing` / `active` / `wip` / `started` / `ongoing`, grey for `todo` / `to do` / `planned` / `backlog` / `open` / `not started` / `new` / `pending`. Any other (or missing) value falls back to the level's colour.
+By default rows sort by start date _within_ the hierarchy — siblings and roots are ordered by date, but children stay grouped under their parent, never flattened. Nested rows share the map's collapse state, so a saved view's collapsed list applies here too.
 
-**`kanban`**
+**Kanban** stacks the same cards into columns by any frontmatter field. All the card configuration carries over; notes with no value gather under a trailing `(none)` column.
 
-| Key       | Type            | Meaning                                                                                                  |
-| --------- | --------------- | -------------------------------------------------------------------------------------------------------- |
-| `groupBy` | field           | Column key (e.g. `status`). **Required.**                                                                |
-| `columns` | list of strings | Explicit column order. Unlisted values found in the data are appended; valueless notes land in `(none)`. |
-| `colors`  | map             | `value → hex` for column headers. Unlisted columns cycle the auto palette.                               |
+Keys for all three live in the [configuration reference](#configuration-reference).
 
-Cards are the same cards as the map (title/sub/meta/progress/labels config all apply), stacked into columns by `groupBy` value.
+## Causal maps
 
-### Migrating from the Project Manager plugin
+A ` ```causalmap ` block renders a **causal-loop diagram** — the multi-connected graph systems thinkers use to diagnose retrospectives and post-mortems and to find leverage points. (Obsidian only for now.)
 
-Task notes written by Project Manager (`pm-task: true` frontmatter with `status`, `start`, `due`, `progress`, `priority`, `assignees`, `tags`, `parentId`/`subtaskIds`, `customFields.*`) render as-is: point a level's `from:` at your `*_tasks` folder, add the `gantt:`/`kanban:` blocks above, done. The plugin never writes task files — edit the note and the view re-renders. Editing, drag-rescheduling, notifications, recurring tasks, and the table view are deliberate non-goals.
-
-## Advanced example
-
-A product strategy tree, showing secondary dashed links, demand bars, and progress bars:
-
-````markdown
-```mindmap
-title: North Star → Drivers → Opportunities → Roadmap
-height: 860
-properties: true
-levels:
-  - { id: northstar, label: NORTH STAR,   from: strategy/north-star,   color: "#1abc9c", card: { title: title, sub: metric } }
-  - { id: drivers,   label: DRIVERS,       from: strategy/drivers,      color: "#9b59b6", card: { title: title, sub: metric } }
-  - { id: opps,      label: OPPORTUNITIES, from: strategy/opportunities, color: "#e67e22", card: { title: title, labels: [kind, horizon], bars: demand } }
-  - { id: roadmap,   label: ROADMAP,       from: strategy/roadmap,      color: "#e74c3c", where: { parentId: null }, card: { title: title, meta: [status], progress: progress } }
-edges:
-  - { from: drivers, to: opps,    via: ladders-to }
-  - { from: opps,    to: roadmap, via: serves }
-  - { from: opps,    to: roadmap, via: alsoServes, secondary: true }   # dashed
-filter: [horizon, kind, status]
-```
-````
-
-## Interactions
-
-The toolbar is a sidebar rail down the left of the map: title and search at the top, then the chip groups (**View**, **Scale**, **Density**, **Rows**, one per filter property, **Saved views**), then a footer with **Display**, **Export**, and the **Reset** / **Help** row.
-
-- **Search** box — spotlight cards matching title / sub / meta, dim the rest.
-- **View** chips — flip the same data between map / gantt / kanban (shown when `gantt:` or `kanban:` is configured).
-- **Scale** / **Density** / **Rows** chips — gantt only: axis unit (week / month / quarter / year), compact vs comfortable row size, and **show subtasks** to expand or contract every parent row at once.
-- **Filter chips** — multi-select per property (OR within, AND across), with options sorted alphabetically.
-- **Saved views** — save the current filter combination + view mode, apply it from the dropdown, edit it, or delete it. Each view also stores which subtrees are collapsed, so applying it restores that shape. Saved views are written to the block's `views:` key, and the selected one to `activeView:`.
-- **Export** — save the current view next to the note as a standalone `.html` file or an editable `.excalidraw` drawing. Both capture what's on screen now, including the active filters, collapse state, and view type.
-- **Hover** a card — highlight its full up/down lineage (in gantt and kanban too, walking the same parent tree).
-- **Click** a card — open a dialog: title + file name, level badge, progress/demand breakdown, its **linked parents, siblings, and children** (click one to jump the dialog there), optional frontmatter properties, the rendered note, "Open note", and "Focus".
-- **Focus** from a card dialog — show that node, its ancestors, and its primary descendants. Focus persists while you pan and click; a **Focus: …** chip appears at the top of the rail, and its **✕** (or **Reset**) clears it.
-- **Titles only** — hide each card's subtitle, meta, bars, and labels, leaving just the title. Hidden in the gantt view, which draws rows rather than cards.
-- **+ / −** on a card, or the per-row toggle in the gantt — collapse / expand its subtree.
-- **«** / **☰** — collapse the toolbar rail to a single button (and expand it back) when it gets in the way.
-- **Help** — open the quick-reference help dialog. **Fullscreen** — toggle fullscreen. **Reset** — clear filters/search/collapse/focus/titles-only, return to the block's default view, and refit.
-- **Drag** to pan, **scroll** to zoom. Clicking empty map space clears the sticky hover highlight.
-
-## Development
-
-```bash
-npm install
-npm run dev     # esbuild watch → main.js (Obsidian) + dist/ (VS Code)
-npm run build   # type-check + production build
-```
-
-Obsidian only loads `main.js`, `manifest.json`, and `styles.css`. For live iteration, symlink this folder into your vault:
-
-```bash
-ln -s "$(pwd)" "<your-vault>/.obsidian/plugins/markdown-mindmap"
-```
-
-(If you use Obsidian Sync, prefer a Release + BRAT, or commit the built files — Sync can remove a hand-linked plugin folder it doesn't recognize.)
-
-### VS Code
-
-The same core also drives a VS Code extension (`src/vscode/`). Unlike Obsidian, it does **not** render inline in the editor — you run a command and the map opens in a panel.
-
-**Run it from source:**
-
-1. Open this repo's folder in VS Code (the adapter lives in `src/vscode/`).
-2. Press `F5` (Run and Debug → **Run Extension**). It builds, then opens an **Extension Development Host** window already pointed at `examples/`.
-3. In that window, open a markdown note that contains a ` ```mindmap ` block (e.g. `mindmap-demo/Mindmap demo.md`).
-4. Command Palette (`Cmd/Ctrl+Shift+P`) → **Markdown Mindmap: Open Map**. The graph opens in a panel beside the note: drag to pan, scroll to zoom, click a card to open that note.
-
-**Notes:**
-
-- **Config source:** the active note's first ` ```mindmap ` block (same YAML as Obsidian).
-- **`from:` paths are relative to the workspace root**, and links resolve by note basename or `title` frontmatter (there's no vault link index outside Obsidian).
-- **Visuals follow your VS Code theme** (via `--vscode-*` variables), so the map looks different from the Obsidian version by design.
-- **Current scope:** render (map, gantt, or kanban per the block's `view:` key) + pan/zoom + click-to-open. The toolbar (search, filter chips, the view switcher, fullscreen, reset), collapse toggles, and the note dialog are Obsidian-only for now.
-
-## Limits
-
-- `from:` is folder-only (no tag / Dataview queries yet).
-- Link resolution matches a wikilink, basename, `title`, or `id` — not an arbitrary shared field value (so a keyword like `stage: claims` won't auto-link unless a note of that basename/title/id exists).
-- Layout centring assumes primary edges connect adjacent levels.
-- Gantt: no dependency arrows and no date-range filtering yet (filters are discrete values). Dates are read, never written — there's no drag-to-reschedule.
-- Excalidraw export is lossy by design: rounded boxes, centred labels, and straight arrows — no curves, progress bars, label pills, or column headers.
-- Causal maps: cycle detection is bounded (at most 64 loops, 12 nodes long), so a very dense graph reports the first loops found rather than every one.
-
-## Causal maps (systems thinking)
-
-Besides trees, the plugin renders **causal-loop diagrams** — multi-connected graphs for systems
-thinking, built for diagnosing retrospectives, post-mortems, and spotting leverage points. One
-fenced ` ```causalmap ` block per diagram (Obsidian only for now).
-
-Each causal variable is a note carrying its **outgoing signed edges** in frontmatter. Topology is
-stored once, on the source note — no separate edge file:
+Each causal variable is a note carrying its **outgoing signed edges** in frontmatter, so the topology is stored once, on the source note, with no separate edge file:
 
 ```yaml
 ---
@@ -358,9 +200,9 @@ affects:
 ---
 ```
 
-The block:
+The block itself just points at the folders:
 
-````yaml
+````markdown
 ```causalmap
 title: Engineering system
 folders: [systems/nodes]
@@ -370,31 +212,201 @@ height: 700
 ```
 ````
 
-What you get:
+What the diagram gives you:
 
-- **Cycles are detected automatically** (bounded simple-cycle search) and classified by sign
-  parity: an even number of `-` edges makes a **reinforcing** loop, odd makes a **balancing**
-  one. No hand-maintained loop lists to drift out of date.
-- **Loop rail**: every detected loop as a chip (● amber = reinforcing, ● teal = balancing);
-  click one to spotlight exactly its edges and nodes — the retro projector view, click again to
-  release. Hovering a chip shows the whole cycle as a `A → B → C → A` tooltip. Loops whose
-  edges share a `loops:` tag take that name and lead the rail alphabetically; a matching card in
-  `loopFolders` (frontmatter `id` + `label`) supplies the display label. Untagged cycles get auto
-  names (`L1`, `L2`, …) and follow in discovery order.
-- **Type legend**: a **Types** rail listing the node types actually present with their colours.
-- **Signed edges**: curved arrows with a `+`/`−` badge; negative links draw dashed.
-- **Deterministic force-directed layout** — the same notes always produce the same picture.
-- Hover a node to light up everything it affects and is affected by; click it for the note
-  dialog (linked rows carry their edge sign); search, fullscreen, HTML export, pan/zoom as in
-  mindmaps.
+- **Loops found for you.** A bounded simple-cycle search detects every feedback loop and classifies it by sign parity — an even number of `-` edges makes a **reinforcing** loop, odd makes a **balancing** one. There is no hand-maintained loop list to fall out of date.
+- **A loop rail.** Each detected loop becomes a chip (● amber = reinforcing, ● teal = balancing); click it to spotlight exactly that cycle's nodes and edges — the retro-projector view — and click again to release. Hovering shows the whole cycle as an `A → B → C → A` tooltip. Loops whose edges share a `loops:` tag take that name and lead the rail alphabetically, with a matching card in `loopFolders` supplying the display label; untagged cycles get auto names (`L1`, `L2`, …) in discovery order.
+- **A type legend** listing the node types actually present, with their colours.
+- **Signed edges** as curved arrows with a `+`/`−` badge; negative links draw dashed.
+- **A deterministic layout.** The force-directed placement has no randomness, so the same notes always produce the same picture.
 
-Other keys: `edgesField` / `labelField` / `typeField` rename the frontmatter fields,
-`typeColors` overrides the per-type palette, `layout: { nodeWidth, spacing, iterations }`
-tunes the drawing, `properties: true` shows all frontmatter in the dialog.
+Hovering a node lights up everything it affects and is affected by; clicking one opens the note dialog, with each linked row carrying its edge sign. Search, fullscreen, HTML export, and pan/zoom work as they do in mindmaps.
 
-> A runnable copy, with sample cards and loop notes, lives in
-> [`examples/causalmap-demo/`](examples/causalmap-demo). Copy that folder into your vault root
-> and open `Causal map demo.md`.
+> A runnable copy, with sample cards and loop notes, lives in [`examples/causalmap-demo/`](examples/causalmap-demo). Copy that folder into your vault root and open `Causal map demo.md`.
+
+## Using a map
+
+The toolbar is a rail down the left: title and search at the top, then chip groups (**View**, **Scale**, **Density**, **Rows**, one per filter property, and **Saved views**), then a footer holding **Display**, **Export**, and the **Reset** / **Help** row.
+
+- **Search** — spotlight cards matching title / sub / meta and dim the rest.
+- **View** chips — flip between map / gantt / kanban (shown once `gantt:` or `kanban:` is configured).
+- **Scale**, **Density**, **Rows** chips — gantt only: the axis unit (week / month / quarter / year), compact vs comfortable row size for presenting, and **show subtasks** to expand or contract every parent row at once.
+- **Filter chips** — multi-select per property, OR within a property and AND across them, options sorted alphabetically.
+- **Saved views** — save the current filters and view type under a name, then apply, edit, or delete it from the dropdown. Each view also remembers which subtrees were collapsed. Views are written back into the block's `views:` key and the selected one into `activeView:`, so your choice survives a restart.
+- **Export** — write the current view next to the note as a standalone `.html` file or an editable `.excalidraw` drawing. Both capture what's on screen: active filters, collapse state, and view type.
+- **Hover** a card — highlight its full up/down lineage, in gantt and kanban as well as the map.
+- **Click** a card — open a dialog with the title and file name, level badge, progress/category breakdown, its **linked parents, siblings, and children** (click one to jump there), optional frontmatter properties, the rendered note, and **Open note** / **Focus** buttons.
+- **Focus** — narrow the map to a node, its ancestors, and its primary descendants. It persists while you pan and click; a **Focus: …** chip at the top of the rail clears it with **✕**.
+- **Titles only** — strip cards back to their titles, hiding subtitle, meta, bars, and labels. (Not shown in the gantt, which draws rows rather than cards.)
+- **+ / −** on a card, or a gantt row's toggle — collapse or expand that subtree.
+- **«** / **☰** — collapse the whole rail to a single button when it's in the way, and bring it back.
+- **Help** opens a quick reference · **Fullscreen** toggles fullscreen · **Reset** clears filters, search, collapse, focus, and titles-only, returns to the block's default view, and refits.
+- **Drag** to pan, **scroll** to zoom. Clicking empty space clears the sticky hover highlight.
+
+## Configuration reference
+
+### `mindmap` — top level
+
+| Key                    | Type            | Meaning                                                                                                                                                          |
+| ---------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `levels`               | list            | Columns, left to right. **Required.**                                                                                                                            |
+| `edges`                | list            | Parent → child links between levels.                                                                                                                             |
+| `title`                | string          | Heading in the toolbar.                                                                                                                                          |
+| `height`               | number          | Component height in px (default `900`).                                                                                                                          |
+| `view`                 | string          | Initial view: `map` (default), `gantt`, or `kanban`.                                                                                                             |
+| `gantt`                | map             | Gantt config (below). Configuring it adds the view to the switcher.                                                                                              |
+| `kanban`               | map             | Kanban config (below). Configuring it adds the view to the switcher.                                                                                             |
+| `filter`               | list of strings | Frontmatter properties exposed as multi-select chip filters.                                                                                                     |
+| `filterLabels`         | map             | Rename a filter group's heading, e.g. `{ customFields.quarters: Quarter }`. Unlisted properties keep their raw name.                                             |
+| `filterKeepsHierarchy` | boolean         | Default `false` (strict): a filtered-out note hides itself **and** its subtree. `true` keeps matches in context — see [above](#how-filters-treat-the-hierarchy). |
+| `layout`               | map             | Override card/column sizing (below). All keys optional.                                                                                                          |
+| `properties`           | boolean         | When `true`, the note dialog shows all frontmatter as a table above the rendered note.                                                                           |
+| `views`                | list            | Saved views (filters + collapse + view type), managed by the toolbar.                                                                                            |
+| `activeView`           | string          | Name of the saved view to re-select on render. Written by the toolbar when you pick one; cleared by **Reset**.                                                   |
+
+### `levels[]`
+
+| Key     | Type       | Meaning                                                                                                                                                                                                                                              |
+| ------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`    | string     | Unique id, referenced by edges. **Required.**                                                                                                                                                                                                        |
+| `from`  | string     | Folder to read notes from (recursive). **Required.**                                                                                                                                                                                                 |
+| `label` | string     | Column header.                                                                                                                                                                                                                                       |
+| `color` | hex string | Column / card-border colour. Defaults cycle the [flatuicolors _defo_](https://flatuicolors.com/palette/defo) palette.                                                                                                                                |
+| `where` | map        | Keep only notes whose frontmatter matches a value, e.g. `{ horizon: now }` to use only drivers with `horizon: now`, or `{ parentId: null }` to keep top-level notes (a `null` target matches null, empty, **or** missing). Multiple keys are AND-ed. |
+| `card`  | map        | Which fields render on the card (below).                                                                                                                                                                                                             |
+
+### `levels[].card`
+
+All card field values are frontmatter property names. Dotted paths work everywhere (`customFields.serves`, `nested.key`).
+
+| Key        | Type             | Renders                                                                                                                                                                              |
+| ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`    | field            | Bold title (falls back to the file name).                                                                                                                                            |
+| `sub`      | field            | Subtitle line.                                                                                                                                                                       |
+| `meta`     | list of fields   | A muted `·`-joined line.                                                                                                                                                             |
+| `progress` | field (0–100)    | A progress bar.                                                                                                                                                                      |
+| `bars`     | field **or** map | A stacked count-by-category bar (below).                                                                                                                                             |
+| `labels`   | list of fields   | Small coloured value pills along the card's bottom strip, one per field (e.g. `[kind, horizon, stage]`). Empty/missing fields drop out; pills that don't fit on one row are skipped. |
+
+**`bars`** takes either a field name or a map. `bars: demand` is shorthand for `bars: { field: demand, category: parens }`.
+
+| Key        | Type                | Meaning                                                                                                                                            |
+| ---------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field`    | field               | The list field to count. **Required.**                                                                                                             |
+| `category` | `parens` \| `value` | How to derive each category. `parens` (default): text in trailing parens, else the value (`"Acme (client)"` → `client`). `value`: the whole value. |
+| `colors`   | map                 | `category → hex`. Categories not listed cycle the auto palette. Omit to use the built-in `client`/`prospect`/`trial`/`customer` defaults.          |
+
+### `edges[]`
+
+| Key         | Type     | Meaning                                                                                                                                                          |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`      | level id | Parent level.                                                                                                                                                    |
+| `to`        | level id | Child level.                                                                                                                                                     |
+| `via`       | field    | The frontmatter field holding the link. By default it lives on the **`to`** notes and points up to a **`from`** note. Dotted paths work (`customFields.serves`). |
+| `reverse`   | bool     | Set `true` when the field lives on the **`from`** notes and points down (e.g. a `serves:` list).                                                                 |
+| `secondary` | bool     | Draw the edge **dashed** and keep it out of the layout spine (for "also relates to" cross-links).                                                                |
+
+### `gantt`
+
+| Key           | Type                                     | Meaning                                                                                                                                  |
+| ------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `start`       | field                                    | Start date (ISO, e.g. `2026-06-09`). **Required.**                                                                                       |
+| `end`         | field                                    | End/due date. **Required.**                                                                                                              |
+| `progress`    | field (0–100)                            | Bar fill. Defaults to the card's `progress` field.                                                                                       |
+| `status`      | field                                    | Field driving the bar/milestone colour (default `status`).                                                                               |
+| `scale`       | `week` \| `month` \| `quarter` \| `year` | Axis tick unit (default `month`). Also switchable from the toolbar's Scale chips.                                                        |
+| `density`     | `compact` \| `comfortable`               | Default `compact`. `comfortable` scales up rows and fonts for reading from a distance. Also switchable from the toolbar's Density chips. |
+| `sortByStart` | bool                                     | Default `true`: rows sort by crescent start date (dateless last). `false` restores the raw tree/path order.                              |
+| `groupRows`   | bool                                     | Default `true`: rows follow the tree order with subtasks indented under parents. `false`: flat path order.                               |
+| `showLabels`  | bool                                     | Default `true`: the card's `labels`, `·`-joined, on a discreet second line under the row title. `false` drops them for a barer chart.    |
+
+### `kanban`
+
+| Key       | Type            | Meaning                                                                                                  |
+| --------- | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `groupBy` | field           | Column key (e.g. `status`). **Required.**                                                                |
+| `columns` | list of strings | Explicit column order. Unlisted values found in the data are appended; valueless notes land in `(none)`. |
+| `colors`  | map             | `value → hex` for column headers. Unlisted columns cycle the auto palette.                               |
+
+### `layout`
+
+| Key          | Default | Meaning                                                                                                                          |
+| ------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `cardWidth`  | `270`   | Card width in px.                                                                                                                |
+| `cardHeight` | `44`    | **Minimum** card height in px. Cards auto-size to their content (title lines, sub, meta, bar, labels); this only sets the floor. |
+| `columnGap`  | `150`   | Horizontal gap between columns.                                                                                                  |
+| `rowGap`     | `12`    | Vertical gap between stacked cards.                                                                                              |
+| `top`        | `64`    | Top margin before the first card.                                                                                                |
+| `titleLines` | `2`     | Title lines shown before truncating. Set `3` to allow longer titles; cards grow to fit automatically.                            |
+| `subLines`   | `1`     | Subtitle (`sub`) lines shown before truncating. Set `2`+ to wrap a long subtitle onto multiple lines; cards grow to fit.         |
+
+### `causalmap`
+
+| Key           | Type            | Meaning                                                                                                          |
+| ------------- | --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `folders`     | list of strings | Folders holding the variable notes. **Required.**                                                                |
+| `loopFolders` | list of strings | Folders with loop cards (frontmatter `id` + `label`) supplying display labels for declared loops.                |
+| `where`       | map             | Keep only notes whose frontmatter matches, e.g. `{ status: active }`.                                            |
+| `edgesField`  | string          | Frontmatter field holding the outgoing edges (default `affects`).                                                |
+| `labelField`  | string          | Field holding the display label (default `label`, falling back to the file name).                                |
+| `typeField`   | string          | Field holding the node type (default `type`).                                                                    |
+| `typeColors`  | map             | `type → hex`, overriding the defaults: driver `#9b59b6`, vice `#e74c3c`, capability `#3498db`, virtue `#2ecc71`. |
+| `title`       | string          | Heading in the toolbar.                                                                                          |
+| `height`      | number          | Component height in px.                                                                                          |
+| `properties`  | boolean         | When `true`, the note dialog shows all frontmatter.                                                              |
+| `layout`      | map             | `nodeWidth` (default `180`), `spacing` (`270`), `iterations` (`300`) — tunes the force-directed drawing.         |
+
+## Using Project Manager task notes
+
+Task notes written by the Project Manager plugin (`pm-task: true` frontmatter with `status`, `start`, `due`, `progress`, `priority`, `assignees`, `tags`, `parentId`/`subtaskIds`, `customFields.*`) render as-is: point a level's `from:` at your `*_tasks` folder, add the `gantt:` and `kanban:` blocks, and you're done.
+
+Markdown Mindmap never writes task files — edit the note and the view re-renders. Editing, drag-rescheduling, notifications, recurring tasks, and the table view are deliberate non-goals.
+
+## VS Code
+
+The same core drives a VS Code extension (`src/vscode/`). Unlike Obsidian it does **not** render inline in the editor — you run a command and the map opens in a panel.
+
+To run it from source:
+
+1. Open this repo's folder in VS Code.
+2. Press `F5` (Run and Debug → **Run Extension**). It builds, then opens an **Extension Development Host** window already pointed at `examples/`.
+3. In that window, open a markdown note containing a ` ```mindmap ` block (e.g. `mindmap-demo/Mindmap demo.md`).
+4. Command Palette (`Cmd/Ctrl+Shift+P`) → **Markdown Mindmap: Open Map**. The graph opens beside the note: drag to pan, scroll to zoom, click a card to open that note.
+
+Some differences from the Obsidian plugin:
+
+- **Config comes from the active note's first ` ```mindmap ` block** (same YAML).
+- **`from:` paths are relative to the workspace root**, and links resolve by note basename or `title` frontmatter — there's no vault link index outside Obsidian.
+- **Visuals follow your VS Code theme** (via `--vscode-*` variables), so the map looks different by design.
+- **Scope is render + pan/zoom + click-to-open**, for whichever view the block's `view:` key selects. The toolbar, collapse toggles, and the note dialog are Obsidian-only for now.
+
+## Limits
+
+- `from:` is folder-only — no tag or Dataview queries yet.
+- Link resolution matches a wikilink, basename, `title`, or `id`, not an arbitrary shared field value: a keyword like `stage: claims` won't auto-link unless a note of that basename/title/id exists.
+- Layout centring assumes primary edges connect adjacent levels.
+- Gantt has no dependency arrows and no date-range filtering (filters are discrete values). Dates are read, never written — there's no drag-to-reschedule.
+- Excalidraw export is lossy by design: rounded boxes, centred labels, straight arrows — no curves, progress bars, label pills, or column headers.
+- Causal-map cycle detection is bounded (at most 64 loops, up to 12 nodes long), so a very dense graph reports the first loops found rather than all of them.
+
+## Development
+
+```bash
+npm install
+npm run dev     # esbuild watch → main.js (Obsidian) + dist/ (VS Code)
+npm run build   # type-check + production build
+npm test        # vitest + coverage
+```
+
+Obsidian loads only `main.js`, `manifest.json`, and `styles.css`. For live iteration, symlink this folder into your vault:
+
+```bash
+ln -s "$(pwd)" "<your-vault>/.obsidian/plugins/markdown-mindmap"
+```
+
+(If you use Obsidian Sync, prefer a Release + BRAT, or commit the built files — Sync can remove a hand-linked plugin folder it doesn't recognize.)
+
+The pure logic lives in `src/core/` behind the `src/graph.ts` barrel, host-free and fully unit-tested; the Obsidian and VS Code adapters wrap it. See [`AGENTS.md`](AGENTS.md) for the architecture and conventions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ It ships as **two adapters over one shared core** (`src/graph.ts`): the **Obsidi
 ## Features
 
 - **Live from frontmatter.** Folders become columns; frontmatter links become edges. Add or remove a note and the map updates.
-- **Three views over one dataset.** The same block renders as a mind **map**, a **gantt** (bars by start/due, progress fill, milestone diamonds), or a **kanban** board (columns by any field) — switch from the toolbar, filters and search apply everywhere.
+- **Three views over one dataset.** The same block renders as a mind **map**, a **gantt** (bars by start/due, progress fill, status colours, a _today_ marker, milestone diamonds), or a **kanban** board (columns by any field) — switch from the toolbar, filters and search apply everywhere.
 - **Per-level card design.** Pick which fields show as title / subtitle / meta per level; cards auto-size to their content.
 - **Edges from links.** A `[[wikilink]]`, plain title, basename, list, or nested field (`customFields.serves`) on either end of an edge.
 - **Secondary (dashed) links.** Mark cross-links that should draw dashed and stay out of the layout spine (e.g. "also relates to").
 - **Bar charts & progress bars.** Render a 0–100 field as a progress bar, or a list field as a stacked count-by-category bar.
-- **Multi-select filters and saved views.** Toggle-chip filters per property (OR within a property, AND across), then save named filter combinations back into the map block. Each saved view also remembers which subtrees are collapsed.
-- **Export.** Save the current map next to the note as a standalone HTML file or an editable Excalidraw drawing.
+- **Multi-select filters and saved views.** Toggle-chip filters per property (OR within a property, AND across), then save named filter combinations back into the map block. Each saved view also remembers which subtrees are collapsed and which view type it opened in, and the one you pick is remembered across Obsidian restarts.
+- **Strict or hierarchy-aware filtering.** By default a filtered-out note takes its subtree with it; set `filterKeepsHierarchy: true` to keep matches in context — their subtasks ride along and their ancestors stay visible.
+- **Export.** Save the current view next to the note as a standalone HTML file or an editable Excalidraw drawing.
 - **Search highlight.** A search box that spotlights matching cards and dims the rest.
-- **Collapse / expand** any subtree, focus a node's lineage/subtree, **pan / zoom / fit / fullscreen**; click a card for a dialog with its linked parents/children, optional properties, and the rendered note.
+- **Collapse / expand** any subtree, focus a node's lineage/subtree, **pan / zoom / fit / fullscreen**; click a card for a dialog with its linked parents/siblings/children, optional properties, and the rendered note.
 - **Theme-aware.** Uses Obsidian CSS variables, so it follows your light/dark theme.
 
 ## How it works
@@ -101,26 +102,28 @@ filter: [status]
 ```
 ````
 
-> A runnable copy of this map, with sample notes, lives in [`examples/mindmap-demo/`](examples/mindmap-demo). Copy that folder into your vault root and open `Mindmap demo.md`.
+> A runnable copy of this map, with sample notes, lives in [`examples/mindmap-demo/`](examples/mindmap-demo). Copy that folder into your vault root and open `Mindmap demo.md`. A second, richer tree — an Opportunity Solution Tree with interview-quote subtitles and a saved view — lives in [`examples/ost-demo/`](examples/ost-demo). See [`examples/README.md`](examples/README.md) for what each demo exercises.
 
 ## Configuration reference
 
 **Top level**
 
-| Key            | Type            | Meaning                                                                                                              |
-| -------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `title`        | string          | Heading in the toolbar.                                                                                              |
-| `height`       | number          | Component height in px (default `900`).                                                                              |
-| `view`         | string          | Initial view: `map` (default), `gantt`, or `kanban`.                                                                 |
-| `levels`       | list            | Columns, left to right. **Required.**                                                                                |
-| `edges`        | list            | Parent → child links between levels.                                                                                 |
-| `gantt`        | map             | Gantt view config (see [Gantt & kanban views](#gantt--kanban-views)). Configuring it adds the view to the switcher.  |
-| `kanban`       | map             | Kanban view config (same section). Configuring it adds the view to the switcher.                                     |
-| `filter`       | list of strings | Frontmatter properties exposed as multi-select chip filters.                                                         |
-| `filterLabels` | map             | Rename a filter group's heading, e.g. `{ customFields.quarters: Quarter }`. Unlisted properties keep their raw name. |
-| `layout`       | map             | Override card/column sizing (below). All keys optional.                                                              |
-| `properties`   | boolean         | When `true`, the note dialog shows all frontmatter as a table above the rendered note.                               |
-| `views`        | list            | Saved views (filters + collapse + view mode), managed by the toolbar's saved-view controls.                          |
+| Key                    | Type            | Meaning                                                                                                                                                    |
+| ---------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | string          | Heading in the toolbar.                                                                                                                                    |
+| `height`               | number          | Component height in px (default `900`).                                                                                                                    |
+| `view`                 | string          | Initial view: `map` (default), `gantt`, or `kanban`.                                                                                                       |
+| `levels`               | list            | Columns, left to right. **Required.**                                                                                                                      |
+| `edges`                | list            | Parent → child links between levels.                                                                                                                       |
+| `gantt`                | map             | Gantt view config (see [Gantt & kanban views](#gantt--kanban-views)). Configuring it adds the view to the switcher.                                        |
+| `kanban`               | map             | Kanban view config (same section). Configuring it adds the view to the switcher.                                                                           |
+| `filter`               | list of strings | Frontmatter properties exposed as multi-select chip filters.                                                                                               |
+| `filterLabels`         | map             | Rename a filter group's heading, e.g. `{ customFields.quarters: Quarter }`. Unlisted properties keep their raw name.                                       |
+| `filterKeepsHierarchy` | boolean         | Default `false` (strict): a filtered-out note hides itself **and** its subtree. `true` keeps context (below).                                              |
+| `layout`               | map             | Override card/column sizing (below). All keys optional.                                                                                                    |
+| `properties`           | boolean         | When `true`, the note dialog shows all frontmatter as a table above the rendered note.                                                                     |
+| `views`                | list            | Saved views (filters + collapse + view mode), managed by the toolbar's saved-view controls.                                                                |
+| `activeView`           | string          | Name of the saved view to re-select on render. Written by the toolbar when you pick one, so the choice survives an Obsidian restart; cleared by **Reset**. |
 
 **`layout`** (all optional, defaults shown)
 
@@ -182,6 +185,15 @@ All card field values are frontmatter property names. Dotted paths work everywhe
 
 A `via` value is matched, in order, against: Obsidian's own link resolution (`[[wikilink]]`), then the target's **basename**, then its `title` frontmatter, then its `id` frontmatter (so pm-style `parentId: p-broker-operator` hierarchies link up). A value may be a single link or a list. A note's **first non-secondary** parent is its layout parent (single-parent tree); any extra parents still draw edges.
 
+### How filters treat the hierarchy
+
+A filter only constrains notes that **have** the property — a note missing it is never filtered out by that chip. What differs is what happens to the notes around a match:
+
+- **Strict (default).** A note that fails the filter hides itself and its whole primary subtree. Good for "show me only the devops tasks", where a parent that isn't devops shouldn't drag its children in.
+- **`filterKeepsHierarchy: true`.** A match keeps its context: its primary **subtree rides along** (a matching epic still shows its subtasks, whatever their own status) and its **ancestors stay visible** as scaffolding. Good for a roadmap where you want the tree shape intact around the hits.
+
+Collapse always applies last, so a contracted subtree stays hidden under either mode.
+
 ## Gantt & kanban views
 
 The same collected + filtered tree can render as a **gantt** or a **kanban** board. Add the config block(s) and a view switcher appears in the toolbar; set `view:` to make one the default. Filters, search, collapse, and saved views apply in every view — a saved view pins **filters + view mode**, so you can keep e.g. a "devops · gantt" view one click away.
@@ -213,12 +225,18 @@ filter: [status, tags]
 | `start`       | field                                    | Start date (ISO, e.g. `2026-06-09`). **Required.**                                                                                                       |
 | `end`         | field                                    | End/due date. **Required.**                                                                                                                              |
 | `progress`    | field (0–100)                            | Bar fill. Defaults to the card's `progress` field.                                                                                                       |
+| `status`      | field                                    | Field driving the bar/milestone colour (default `status`). See the status colours below.                                                                 |
 | `scale`       | `week` \| `month` \| `quarter` \| `year` | Axis tick unit (default `month`). Also switchable from the toolbar's Scale chips.                                                                        |
 | `density`     | `compact` \| `comfortable`               | Default `compact`. `comfortable` scales up rows and fonts for reading from a distance (presentations). Also switchable from the toolbar's Density chips. |
 | `sortByStart` | bool                                     | Default `true`: rows sort by crescent start date (dateless last). `false` restores the raw tree/path order.                                              |
 | `groupRows`   | bool                                     | Default `true`: rows follow the tree order with subtasks indented under parents. `false`: flat path order.                                               |
+| `showLabels`  | bool                                     | Default `true`: the card's `labels`, `·`-joined, on a discreet second line under the row title. `false` drops them for a barer chart.                    |
 
-Rows render as bars from `start` to `end` with a progress fill. A task whose `start` equals its `end` (or that has only one of the two) renders as a **milestone diamond**. Tasks with neither date get a plain row. Click a row to open the note. The card's `labels` render as pills right of the bar (or at the axis origin for dateless rows). Nested items can be contracted/expanded with a per-row toggle — the same collapse state as the map view, so saved views' collapsed lists apply here too. The toolbar's **show subtasks** chip (under **Rows**) expands/contracts every parent row at once; it's off by default, so the gantt opens with nested rows hidden.
+Rows render as bars from `start` to `end` with a progress fill. A task whose `start` equals its `end` (or that has only one of the two) renders as a **milestone diamond**. Tasks with neither date get a plain row. Click a row to open the note; hover one for a native tooltip with the full title, date range, status, progress, and tags. A vertical **today** marker is drawn when the current date falls inside the charted range.
+
+`sortByStart` sorts _within_ the hierarchy: siblings (and roots) are ordered by start date, but children stay grouped under their parent — the tree is never flattened. Nested items can be contracted/expanded with a per-row toggle, sharing the map view's collapse state, so saved views' collapsed lists apply here too. The toolbar's **show subtasks** chip (under **Rows**) expands/contracts every parent row at once; it's on by default, so the gantt opens with nested rows showing.
+
+**Status colours.** Bars and milestones colour themselves from the `status` field, matched case- and space-insensitively: green for `done` / `complete` / `completed` / `closed` / `shipped`, blue for `in progress` / `in-progress` / `doing` / `active` / `wip` / `started` / `ongoing`, grey for `todo` / `to do` / `planned` / `backlog` / `open` / `not started` / `new` / `pending`. Any other (or missing) value falls back to the level's colour.
 
 **`kanban`**
 
@@ -258,20 +276,22 @@ filter: [horizon, kind, status]
 
 ## Interactions
 
+The toolbar is a sidebar rail down the left of the map: title and search at the top, then the chip groups (**View**, **Scale**, **Density**, **Rows**, one per filter property, **Saved views**), then a footer with **Display**, **Export**, and the **Reset** / **Help** row.
+
 - **Search** box — spotlight cards matching title / sub / meta, dim the rest.
-- **View switcher** — flip the same data between map / gantt / kanban (shown when `gantt:` or `kanban:` is configured).
+- **View** chips — flip the same data between map / gantt / kanban (shown when `gantt:` or `kanban:` is configured).
+- **Scale** / **Density** / **Rows** chips — gantt only: axis unit (week / month / quarter / year), compact vs comfortable row size, and **show subtasks** to expand or contract every parent row at once.
 - **Filter chips** — multi-select per property (OR within, AND across), with options sorted alphabetically.
-- **Saved views** — save the current filter combination + view mode, apply it from the dropdown, edit it, or delete it. Each view also stores which subtrees are collapsed, so applying it restores that shape. Saved views are written to the block's `views:` key.
-- **Export** — save the current map next to the note as a standalone `.html` file or an editable `.excalidraw` drawing.
-- **Hover** a card — highlight its full up/down lineage.
+- **Saved views** — save the current filter combination + view mode, apply it from the dropdown, edit it, or delete it. Each view also stores which subtrees are collapsed, so applying it restores that shape. Saved views are written to the block's `views:` key, and the selected one to `activeView:`.
+- **Export** — save the current view next to the note as a standalone `.html` file or an editable `.excalidraw` drawing. Both capture what's on screen now, including the active filters, collapse state, and view type.
+- **Hover** a card — highlight its full up/down lineage (in gantt and kanban too, walking the same parent tree).
 - **Click** a card — open a dialog: title + file name, level badge, progress/demand breakdown, its **linked parents, siblings, and children** (click one to jump the dialog there), optional frontmatter properties, the rendered note, "Open note", and "Focus".
-- **Focus** from a card dialog — show that node, its ancestors, and its primary descendants; click empty map space to clear focus.
-- **Titles only** — toggle the toolbar button to hide each card's subtitle, meta, bars, and labels, leaving just the title.
-- **+ / −** on a card — collapse / expand its subtree.
-- **⟨ / ☰** — collapse the toolbar to a single button (and expand it back) when it gets in the way.
-- **?** — open the quick-reference help dialog.
-- **⛶** — fullscreen. **Reset** — clear filters/search/collapse/focus and refit.
-- **Drag** to pan, **scroll** to zoom.
+- **Focus** from a card dialog — show that node, its ancestors, and its primary descendants. Focus persists while you pan and click; a **Focus: …** chip appears at the top of the rail, and its **✕** (or **Reset**) clears it.
+- **Titles only** — hide each card's subtitle, meta, bars, and labels, leaving just the title. Hidden in the gantt view, which draws rows rather than cards.
+- **+ / −** on a card, or the per-row toggle in the gantt — collapse / expand its subtree.
+- **«** / **☰** — collapse the toolbar rail to a single button (and expand it back) when it gets in the way.
+- **Help** — open the quick-reference help dialog. **Fullscreen** — toggle fullscreen. **Reset** — clear filters/search/collapse/focus/titles-only, return to the block's default view, and refit.
+- **Drag** to pan, **scroll** to zoom. Clicking empty map space clears the sticky hover highlight.
 
 ## Development
 
@@ -312,7 +332,9 @@ The same core also drives a VS Code extension (`src/vscode/`). Unlike Obsidian, 
 - `from:` is folder-only (no tag / Dataview queries yet).
 - Link resolution matches a wikilink, basename, `title`, or `id` — not an arbitrary shared field value (so a keyword like `stage: claims` won't auto-link unless a note of that basename/title/id exists).
 - Layout centring assumes primary edges connect adjacent levels.
-- Gantt: no dependency arrows and no date-range filtering yet (filters are discrete values).
+- Gantt: no dependency arrows and no date-range filtering yet (filters are discrete values). Dates are read, never written — there's no drag-to-reschedule.
+- Excalidraw export is lossy by design: rounded boxes, centred labels, and straight arrows — no curves, progress bars, label pills, or column headers.
+- Causal maps: cycle detection is bounded (at most 64 loops, 12 nodes long), so a very dense graph reports the first loops found rather than every one.
 
 ## Causal maps (systems thinking)
 
@@ -354,9 +376,12 @@ What you get:
   parity: an even number of `-` edges makes a **reinforcing** loop, odd makes a **balancing**
   one. No hand-maintained loop lists to drift out of date.
 - **Loop rail**: every detected loop as a chip (● amber = reinforcing, ● teal = balancing);
-  click one to spotlight exactly its edges and nodes — the retro projector view. Loops whose
-  edges share a `loops:` tag take that name; a matching card in `loopFolders` (frontmatter
-  `id` + `label`) supplies the display label. Untagged cycles get auto names (`L1`, `L2`, …).
+  click one to spotlight exactly its edges and nodes — the retro projector view, click again to
+  release. Hovering a chip shows the whole cycle as a `A → B → C → A` tooltip. Loops whose
+  edges share a `loops:` tag take that name and lead the rail alphabetically; a matching card in
+  `loopFolders` (frontmatter `id` + `label`) supplies the display label. Untagged cycles get auto
+  names (`L1`, `L2`, …) and follow in discovery order.
+- **Type legend**: a **Types** rail listing the node types actually present with their colours.
 - **Signed edges**: curved arrows with a `+`/`−` badge; negative links draw dashed.
 - **Deterministic force-directed layout** — the same notes always produce the same picture.
 - Hover a node to light up everything it affects and is affected by; click it for the note

--- a/src/obsidian/modals.ts
+++ b/src/obsidian/modals.ts
@@ -137,19 +137,27 @@ filter: [status]
 - **view** — initial view: \`map\` (default), \`gantt\`, or \`kanban\`
 - **levels** — columns, left to right (**required**)
 - **edges** — parent → child links between levels
-- **gantt** — gantt view config: \`{ start, end, progress?, scale?, groupRows? }\` (field names; scale: week/month/quarter)
+- **gantt** — gantt view config: \`{ start, end, progress?, status?, scale?, density?, groupRows?, sortByStart?, showLabels? }\` (field names; scale: week/month/quarter/year)
 - **kanban** — kanban view config: \`{ groupBy, columns?, colors? }\`
 - **filter** — properties shown as chip filters
 - **filterLabels** — rename a filter group's heading
+- **filterKeepsHierarchy: true** — keep matches in context: their subtree rides along and their ancestors stay visible (default \`false\` = a filtered-out note hides its subtree too)
 - **layout** — override card/column sizing
 - **properties: true** — show all frontmatter in the note dialog
 - **views** — saved views: filters + collapse + view mode (managed by the toolbar)
+- **activeView** — the saved view to re-select on render (written when you pick one, so it survives a restart)
 
 ### Views
 Configuring \`gantt:\` or \`kanban:\` adds a **View** switcher to the toolbar; the same
 filtered tree renders as a mind map, a gantt (bars start→end, progress fill, a
 diamond when start = end or one date is missing), or a kanban board (columns by
 \`groupBy\`). Filters, search, collapse, and saved views apply in every view.
+
+In the gantt, bars colour themselves from the \`status\` field (green = done, blue =
+in progress, grey = todo; anything else falls back to the level colour), a vertical
+**today** marker is drawn when today is in range, and hovering a row shows the
+title, dates, status, progress, and tags. The **Scale**, **Density**, and **Rows**
+chip groups switch the axis unit, the row size, and whether nested rows show.
 
 ### Each level
 - **id** (required) — referenced by edges
@@ -179,14 +187,14 @@ Field values are frontmatter property names; dotted paths work everywhere (\`cus
 - **View switcher** — flip between map / gantt / kanban
 - **Filter chips** — multi-select per property (OR within, AND across)
 - **Saved views** — save / apply / edit / delete a filter + view-mode combination; each view also remembers which subtrees are collapsed
-- **Export** — save the current map next to the note as a standalone **HTML** file or an editable **Excalidraw** drawing
+- **Export** — save the current view next to the note as a standalone **HTML** file or an editable **Excalidraw** drawing (both capture the filters/collapse/view showing now)
 - **Hover** a card — highlight its full up/down lineage
 - **Click** a card — dialog with its linked parents, siblings, and children (click to jump), properties, and the rendered note
-- **Focus** (from the dialog) — show a node, its ancestors, and primary descendants; persists until you click empty map space to clear
-- **Titles only** — hide subtitle/meta/bars/labels, leaving just titles
-- **+ / −** — collapse / expand a subtree
-- **⟨ / ☰** — collapse the toolbar to a single button, or expand it back
-- **⛶** fullscreen · **Reset** clears filters/search/collapse/focus · drag to pan, scroll to zoom
+- **Focus** (from the dialog) — show a node, its ancestors, and primary descendants; it persists while you pan and click, and the **Focus: …** chip's **✕** at the top of the rail clears it
+- **Titles only** — hide subtitle/meta/bars/labels, leaving just titles (map + kanban)
+- **+ / −** — collapse / expand a subtree, on a card or a gantt row
+- **«** / **☰** — collapse the toolbar rail to a single button, or expand it back
+- **Fullscreen** · **Reset** clears filters/search/collapse/focus and returns to the default view · drag to pan, scroll to zoom
 
 ## Causal maps (systems thinking)
 


### PR DESCRIPTION
The docs had drifted behind several releases. Corrected what was wrong and
documented what was missing, in both the README and the HELP cheat sheet the
plugin ships (it can't read the README at runtime, so it drifts separately).

Wrong:
- gantt "show subtasks" is on by default, not off — the view opens expanded
- focus is cleared by the Focus chip's ✕ / Reset, not by clicking empty space
- gantt labels draw under the row title, not as pills beside the bar
- toolbar controls are labelled buttons (Help / Fullscreen / Reset) grouped
  under Display / Export, not the ?/⛶ glyphs; the rail toggle is «

Missing:
- filterKeepsHierarchy and activeView top-level keys
- gantt status / showLabels keys, status colours, today marker, row tooltips
- the focus ticket, gantt Scale/Density/Rows chip groups, sortByStart's
  within-hierarchy sorting
- causal-map type legend, loop-chip tooltips, loop rail ordering
- the ost-demo example, plus Excalidraw and cycle-detection limits

AGENTS.md: correct the src/obsidian/ file list (modals.ts imports obsidian
too) and note that the three doc surfaces have to move together.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KbtVmHbXHfifLzg4voJFuS