### PR TITLE
docs: describe all four view types in the plugin description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Markdown Mindmap",
   "version": "1.4.1",
   "minAppVersion": "1.8.0",
-  "description": "Render configurable mind maps / leveled trees from your notes' frontmatter links. Define each map in a ```mindmap code block.",
+  "description": "Render mind maps, gantt charts, kanban boards, and causal-loop diagrams from your notes' frontmatter links. Each map is one fenced code block.",
   "author": "Kiko Castro",
   "authorUrl": "https://github.com/kikocastro",
   "isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-mindmap",
   "displayName": "Markdown Mindmap",
   "version": "1.4.1",
-  "description": "Configurable mind maps / leveled trees from note frontmatter links. Obsidian plugin + VS Code extension over one shared core.",
+  "description": "Mind maps, gantt charts, kanban boards, and causal-loop diagrams from note frontmatter links. Obsidian plugin + VS Code extension over one shared core.",
   "main": "dist/extension.js",
   "engines": {
     "vscode": "^1.125.0"


### PR DESCRIPTION
Rebased onto `main` after #14 merged. That PR carried the README sync and restructure, so this one is now down to the single remaining change: the plugin description.

`manifest.json`'s description still said "configurable mind maps / leveled trees", which predated the gantt, kanban, and causal-map views — it undersold three of the four things the plugin draws. It's the text users see in their installed-plugins list, so it's worth correcting.

```diff
-Render configurable mind maps / leveled trees from your notes' frontmatter links. Define each map in a ```mindmap code block.
+Render mind maps, gantt charts, kanban boards, and causal-loop diagrams from your notes' frontmatter links. Each map is one fenced code block.
```

`package.json`'s description gets the same treatment for consistency. Two files, one line each.

The new text omits the word "Obsidian", per the plugin directory's submission guideline.

## Why this needs a release

Unlike the README — which Obsidian pulls from the repo's default branch, so #14 is already live on the plugin detail page — `manifest.json` ships as a **release asset**. This description only reaches users when they update the plugin. So merging this should be followed by a 1.4.2 patch release (`npm version patch` → `git push --follow-tags`, which triggers `release.yml`).

> [!NOTE]
> The one-line blurb in the community plugin **browser** is a third, separate thing: it lives in `community-plugins.json` in `obsidianmd/obsidian-releases` and needs its own PR there. Neither this PR nor the release will change it.

## Verification

- `npm test` — 326 passing, 100% statements/branches/functions/lines
- `npm run typecheck` — clean
- No source changes; `main.js` output is unaffected by the manifest edit