### PR TITLE
feat: add a Refresh button to re-read note frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Hovering a node lights up everything it affects and is affected by; clicking one
 
 ## Using a map
 
-The toolbar is a rail down the left: title and search at the top, then chip groups (**View**, **Scale**, **Density**, **Rows**, one per filter property, and **Saved views**), then a footer holding **Display**, **Export**, and the **Reset** / **Help** row.
+The toolbar is a rail down the left: title and search at the top, then chip groups (**View**, **Scale**, **Density**, **Rows**, one per filter property, and **Saved views**), then a footer holding **Display**, **Export**, and the **Reset** / **Refresh** / **Help** row.
 
 - **Search** — spotlight cards matching title / sub / meta and dim the rest.
 - **View** chips — flip between map / gantt / kanban (shown once `gantt:` or `kanban:` is configured).
@@ -240,6 +240,7 @@ The toolbar is a rail down the left: title and search at the top, then chip grou
 - **Titles only** — strip cards back to their titles, hiding subtitle, meta, bars, and labels. (Not shown in the gantt, which draws rows rather than cards.)
 - **+ / −** on a card, or a gantt row's toggle — collapse or expand that subtree.
 - **«** / **☰** — collapse the whole rail to a single button when it's in the way, and bring it back.
+- **Refresh** — re-read every note's frontmatter and redraw. A map reads the vault once, when the block renders, so edits to the notes it maps (a changed `gantt.end`, a new `status:`) don't show until the block re-runs. Your filters, view type, and collapse state carry over; pan/zoom and search do not, and it exits fullscreen.
 - **Help** opens a quick reference · **Fullscreen** toggles fullscreen · **Reset** clears filters, search, collapse, focus, and titles-only, returns to the block's default view, and refits.
 - **Drag** to pan, **scroll** to zoom. Clicking empty space clears the sticky hover highlight.
 

--- a/src/obsidian/main.ts
+++ b/src/obsidian/main.ts
@@ -475,7 +475,7 @@ function renderMindmap(
   });
   exportExBtn.onclick = exportExcalidraw;
 
-  // global utilities share one bottom row: Reset hugs the left, Help the right
+  // global utilities share one bottom row: Reset, Refresh, Help
   const footUtil = foot.createDiv({ cls: "mm-utilrow" });
 
   plugin.registerDomEvent(activeDocument, "fullscreenchange", () => {
@@ -655,6 +655,20 @@ function renderMindmap(
     fit();
     if (cfg.activeView) persistActiveView("").catch(reportViewError);
   };
+
+  // Frontmatter is read once, when the block renders (see the vault scan at the top of
+  // renderMindmap), so editing a child note leaves the map stale until something re-runs the
+  // processor. Re-invoking renderMindmap re-scans the vault; activeState (written on every
+  // draw) restores the view/filters/collapse across the teardown.
+  // ponytail: explicit button, not a metadataCache listener — an auto-redraw would reset
+  // pan/zoom and drop out of fullscreen on every unrelated vault edit. Also leaks one set of
+  // plugin-scoped window listeners per press, same as the existing persist re-render does;
+  // add teardown if that ever shows up in a profile.
+  const refreshBtn = footUtil.createEl("button", {
+    text: "Refresh",
+    attr: { title: "Re-read note frontmatter and redraw" },
+  });
+  refreshBtn.onclick = () => renderMindmap(app, plugin, source, host, ctx);
 
   const helpBtn = footUtil.createEl("button", {
     cls: "mm-help",

--- a/src/obsidian/modals.ts
+++ b/src/obsidian/modals.ts
@@ -194,6 +194,7 @@ Field values are frontmatter property names; dotted paths work everywhere (\`cus
 - **Titles only** — hide subtitle/meta/bars/labels, leaving just titles (map + kanban)
 - **+ / −** — collapse / expand a subtree, on a card or a gantt row
 - **«** / **☰** — collapse the toolbar rail to a single button, or expand it back
+- **Refresh** — re-read note frontmatter and redraw; a map reads the vault once when the block renders, so edits to mapped notes only show after a refresh (filters/view/collapse carry over, pan/zoom does not)
 - **Fullscreen** · **Reset** clears filters/search/collapse/focus and returns to the default view · drag to pan, scroll to zoom
 
 ## Causal maps (systems thinking)

--- a/styles.css
+++ b/styles.css
@@ -227,6 +227,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 4px;
 }
 
 /* focus banner: the label ellipsises, the ✕ always stays visible at the right */


### PR DESCRIPTION
## Why

A map scans the vault once, at the moment the code block renders (`src/obsidian/main.ts:111`). There's no `metadataCache` listener, so editing a note the map draws (a new `gantt.end`, a changed `status:`) leaves the map stale until something re-runs the processor. Today that means toggling the note between edit and reading mode, or saving a view and letting the YAML write-back re-render as a side effect.

## What

A **Refresh** button in the toolbar's util row (Reset · Refresh · Help). It re-invokes `renderMindmap` on the same host element, which re-scans the vault. `activeState` (written on every `draw()`) restores view, filters, and collapse across the teardown. Pan/zoom, search, and fullscreen do not survive, same as any other re-render.

Explicit button rather than `metadataCache.on("changed")`: an auto-redraw tears down the DOM, so it would reset pan/zoom and kick you out of fullscreen on every unrelated vault edit. Noted as a `ponytail:` comment along with the pre-existing per-re-render window-listener leak.

Docs updated in both required places: `README.md` and the `HELP` string in `src/obsidian/modals.ts`.

## Verification

`npm run typecheck` clean, `npm test` 326 passing, coverage still 100%. `npm run build` produces `main.js`, and the build is installed into the `cit/product` vault. **Not yet clicked in Obsidian** — needs a manual check there (the repo's convention is that DOM code is validated by build plus a manual Obsidian pass, not unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)